### PR TITLE
Update Godot docs with pre-built binary download options

### DIFF
--- a/plugins/godot/SKILL.md
+++ b/plugins/godot/SKILL.md
@@ -195,7 +195,12 @@ python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install playgodot
 
-# Build custom Godot fork
+# Option 1: Download pre-built binary (recommended)
+# See releases: https://github.com/Randroids-Dojo/godot/releases/tag/automation-latest
+# - godot-automation-linux-x86_64.zip
+# - godot-automation-macos-universal.zip (Intel + Apple Silicon)
+
+# Option 2: Build custom Godot fork from source
 git clone https://github.com/Randroids-Dojo/godot.git
 cd godot && git checkout automation
 scons platform=macos arch=arm64 target=editor -j8  # macOS Apple Silicon

--- a/plugins/godot/references/ci-integration.md
+++ b/plugins/godot/references/ci-integration.md
@@ -326,8 +326,12 @@ jobs:
         run: |
           mkdir -p godot-automation
           cd godot-automation
+          # Linux x86_64:
           curl -L -o godot.zip \
             "https://github.com/Randroids-Dojo/godot/releases/download/automation-latest/godot-automation-linux-x86_64.zip"
+          # macOS (universal - Intel + Apple Silicon):
+          # curl -L -o godot.zip \
+          #   "https://github.com/Randroids-Dojo/godot/releases/download/automation-latest/godot-automation-macos-universal.zip"
           unzip godot.zip
           chmod +x godot.linuxbsd.editor.x86_64
 

--- a/plugins/godot/references/playgodot.md
+++ b/plugins/godot/references/playgodot.md
@@ -16,7 +16,12 @@ python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\Scripts\activate
 pip install playgodot
 
-# Build custom Godot fork
+# Option 1: Download pre-built binary (recommended)
+# See releases: https://github.com/Randroids-Dojo/godot/releases/tag/automation-latest
+# - godot-automation-linux-x86_64.zip
+# - godot-automation-macos-universal.zip (Intel + Apple Silicon)
+
+# Option 2: Build custom Godot fork from source
 git clone https://github.com/Randroids-Dojo/godot.git
 cd godot && git checkout automation
 scons platform=macos arch=arm64 target=editor -j8  # macOS Apple Silicon


### PR DESCRIPTION
Add documentation for downloading pre-built automation binaries from
the Godot fork releases instead of building from source. The fork now
provides godot-automation-linux-x86_64.zip and a universal macOS build
that supports both Intel and Apple Silicon architectures.