### PR TITLE
Add SlipBox skill for knowledge engine and PrivateBox integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -23,6 +23,11 @@
       "name": "unreal",
       "source": "./plugins/unreal",
       "description": "Develop, test, and automate Unreal Engine 5.x projects (WIP). Covers PlayUnreal automation, Remote Control API, Automation Driver, and CI-friendly E2E workflows. PlayUnreal: https://github.com/Randroids-Dojo/PlayUnreal"
+    },
+    {
+      "name": "slipbox",
+      "source": "./plugins/slipbox",
+      "description": "Interact with the SlipBox semantic knowledge engine and read notes from PrivateBox. Capture atomic ideas, browse the knowledge graph, and run semantic analysis passes (link, cluster, tension). Service: /Users/randroid/Documents/Dev/SlipBox. Notes: https://github.com/Randroids-Dojo/PrivateBox"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A dual-format skills repository for **Claude Code**, **Codex CLI**, and **OpenCo
 | **task-tracking-dots** | Task management with Dots using the dot CLI for tracking work items |
 | **godot** | Develop, test, build, and deploy Godot 4.x games |
 | **unreal** | Develop, test, and automate Unreal Engine 5.x projects (WIP). PlayUnreal: https://github.com/Randroids-Dojo/PlayUnreal |
+| **slipbox** | Interact with the SlipBox semantic knowledge engine and read notes from PrivateBox |
 
 ## Installation
 
@@ -41,6 +42,12 @@ To install the Unreal skill:
 npx skills add https://github.com/Randroids-Dojo/skills --skill unreal
 ```
 
+To install the SlipBox skill:
+
+```bash
+npx skills add https://github.com/Randroids-Dojo/skills --skill slipbox
+```
+
 ### Manual installs
 
 #### Codex CLI
@@ -52,6 +59,7 @@ $skill-installer https://github.com/Randroids-Dojo/skills/tree/main/plugins/loop
 $skill-installer https://github.com/Randroids-Dojo/skills/tree/main/plugins/task-tracking-dots
 $skill-installer https://github.com/Randroids-Dojo/skills/tree/main/plugins/godot
 $skill-installer https://github.com/Randroids-Dojo/skills/tree/main/plugins/unreal
+$skill-installer https://github.com/Randroids-Dojo/skills/tree/main/plugins/slipbox
 ```
 
 Or clone for all skills at once:
@@ -67,6 +75,7 @@ ln -s ~/.codex/skills/randroids-dojo/plugins/loop ~/.codex/skills/loop
 ln -s ~/.codex/skills/randroids-dojo/plugins/task-tracking-dots ~/.codex/skills/task-tracking-dots
 ln -s ~/.codex/skills/randroids-dojo/plugins/godot ~/.codex/skills/godot
 ln -s ~/.codex/skills/randroids-dojo/plugins/unreal ~/.codex/skills/unreal
+ln -s ~/.codex/skills/randroids-dojo/plugins/slipbox ~/.codex/skills/slipbox
 ```
 
 #### Claude Code
@@ -79,6 +88,7 @@ Install from the marketplace:
 /plugin install task-tracking-dots
 /plugin install godot
 /plugin install unreal
+/plugin install slipbox
 ```
 
 ### Install locations (Skills CLI)
@@ -102,6 +112,7 @@ $loop               # Invoke loop skill
 $task-tracking-dots # Task management with Dots
 $godot              # Invoke godot skill
 $unreal             # Invoke unreal skill
+$slipbox            # Invoke slipbox skill
 ```
 
 ### Claude Code
@@ -111,6 +122,7 @@ $unreal             # Invoke unreal skill
 /task-tracking-dots # Task management with Dots
 /godot:godot        # Godot development assistance
 /unreal:unreal      # Unreal development assistance
+/slipbox:slipbox    # SlipBox knowledge engine
 ```
 
 ## Repository Structure
@@ -136,11 +148,14 @@ $unreal             # Invoke unreal skill
 │   │   ├── commands/        # Claude Code slash commands
 │   │   ├── scripts/         # Helper scripts
 │   │   └── references/      # Documentation
-│   └── unreal/
+│   ├── unreal/
+│   │   ├── SKILL.md         # Skill definition (Codex + Claude)
+│   │   ├── commands/        # Claude Code slash commands
+│   │   ├── scripts/         # Helper scripts
+│   │   └── references/      # Documentation
+│   └── slipbox/
 │       ├── SKILL.md         # Skill definition (Codex + Claude)
-│       ├── commands/        # Claude Code slash commands
-│       ├── scripts/         # Helper scripts
-│       └── references/      # Documentation
+│       └── commands/        # Claude Code slash commands
 └── README.md
 ```
 

--- a/plugins/slipbox/SKILL.md
+++ b/plugins/slipbox/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: slipbox
+description: Interact with the SlipBox semantic knowledge engine and read notes from PrivateBox. Use when capturing ideas, searching notes, browsing your knowledge graph, or running semantic analysis passes (link, cluster, tension). SlipBox service: /Users/randroid/Documents/Dev/SlipBox. Notes repo: https://github.com/Randroids-Dojo/PrivateBox.
+compatibility: Requires SLIPBOX_API_KEY env var. Reading PrivateBox notes requires GITHUB_TOKEN or the gh CLI.
+---
+
+# SlipBox Skill
+
+Interact with the SlipBox semantic knowledge engine and browse your PrivateBox notes.
+
+**SlipBox service**: `/Users/randroid/Documents/Dev/SlipBox` (local) or deployed Vercel URL
+**PrivateBox repo**: https://github.com/Randroids-Dojo/PrivateBox
+
+## Configuration
+
+Required environment variables (set in shell or `.env.local` in the SlipBox project):
+
+```env
+SLIPBOX_API_KEY=<shared-secret>       # Bearer token for API auth
+OPENAI_API_KEY=<openai-key>           # Required by the service for embeddings
+GITHUB_TOKEN=<fine-grained-pat>       # Read/write PrivateBox
+PRIVATEBOX_OWNER=Randroids-Dojo       # GitHub owner
+PRIVATEBOX_REPO=PrivateBox            # Repository name
+```
+
+Confirm the service is running before making API calls:
+
+```bash
+curl -s http://localhost:3000/api/health
+# {"status":"ok"}
+```
+
+---
+
+## Quick Reference
+
+All API calls require: `Authorization: Bearer $SLIPBOX_API_KEY`
+
+```bash
+# Health check
+curl -s http://localhost:3000/api/health
+
+# Add a note
+curl -s -X POST http://localhost:3000/api/add-note \
+  -H "Authorization: Bearer $SLIPBOX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "Atomic idea goes here."}'
+
+# Re-link all notes (recompute similarity links)
+curl -s -X POST http://localhost:3000/api/link-pass \
+  -H "Authorization: Bearer $SLIPBOX_API_KEY"
+
+# Cluster notes into thematic groups
+curl -s -X POST http://localhost:3000/api/cluster-pass \
+  -H "Authorization: Bearer $SLIPBOX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"k": 5}'
+
+# Detect conceptual tensions (contradictions within clusters)
+curl -s -X POST http://localhost:3000/api/tension-pass \
+  -H "Authorization: Bearer $SLIPBOX_API_KEY"
+```
+
+---
+
+## API Reference
+
+### POST /api/add-note
+
+Capture an atomic idea. SlipBox embeds it, links it to similar notes, and commits it to PrivateBox.
+
+```bash
+curl -s -X POST http://localhost:3000/api/add-note \
+  -H "Authorization: Bearer $SLIPBOX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "content": "The Zettelkasten method treats each note as a discrete, reusable idea."
+  }'
+```
+
+Response:
+```json
+{
+  "noteId": "20260222T153045-a1b2c3d4",
+  "linkedNotes": [
+    {"noteId": "20260110T091200-b2c3d4e5", "similarity": 0.91},
+    {"noteId": "20260115T143000-c3d4e5f6", "similarity": 0.85}
+  ]
+}
+```
+
+### POST /api/link-pass
+
+Recompute semantic similarity links across all notes. Run after adding many notes in bulk.
+
+```bash
+curl -s -X POST http://localhost:3000/api/link-pass \
+  -H "Authorization: Bearer $SLIPBOX_API_KEY"
+```
+
+Response:
+```json
+{"message": "Link pass complete", "notesProcessed": 42, "totalLinks": 156}
+```
+
+### POST /api/cluster-pass
+
+Run k-means clustering on note embeddings. Omit `k` to auto-select cluster count.
+
+```bash
+curl -s -X POST http://localhost:3000/api/cluster-pass \
+  -H "Authorization: Bearer $SLIPBOX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"k": 5}'
+```
+
+Response:
+```json
+{
+  "message": "Cluster pass complete",
+  "noteCount": 42,
+  "clusterCount": 5,
+  "clusters": [{"id": 0, "notes": ["20260222T153045-a1b2c3d4", ...]}, ...]
+}
+```
+
+### POST /api/tension-pass
+
+Detect conceptual tensions — notes with contradictory content that cluster near each other.
+
+```bash
+curl -s -X POST http://localhost:3000/api/tension-pass \
+  -H "Authorization: Bearer $SLIPBOX_API_KEY"
+```
+
+Response:
+```json
+{
+  "message": "Tension pass complete",
+  "noteCount": 42,
+  "clusterCount": 5,
+  "tensionCount": 8,
+  "tensions": [{"noteA": "...", "noteB": "...", "similarity": 0.68}, ...]
+}
+```
+
+---
+
+## Note Format
+
+Notes in PrivateBox are Markdown files with YAML frontmatter:
+
+```markdown
+---
+id: 20260222T153045-a1b2c3d4
+title: "Optional title"
+tags: ["tag1", "tag2"]
+source: "URL or origin"
+created: 2026-02-22T15:30:45.000Z
+updated: 2026-02-22T15:30:45.000Z
+links:
+  - target: 20260110T091200-b2c3d4e5
+    similarity: 0.91
+  - target: 20260115T143000-c3d4e5f6
+    similarity: 0.85
+---
+
+Atomic idea content in Markdown.
+```
+
+**Note ID format**: `YYYYMMDDTHHMMSS-<8hex>` (timestamp + content hash)
+
+**Index files** (in `index/` directory of PrivateBox):
+- `index/embeddings.json` — noteId → vector + model + timestamp
+- `index/backlinks.json` — noteId → array of linking notes
+- `index/clusters.json` — thematic groups of notes
+- `index/tensions.json` — pairs of contradictory notes
+
+---
+
+## Reading Notes from PrivateBox
+
+Use the `gh` CLI to read notes without needing direct GitHub API calls.
+
+```bash
+# List all notes
+gh api repos/Randroids-Dojo/PrivateBox/contents/notes \
+  --jq '.[].name'
+
+# Read a specific note by ID
+gh api repos/Randroids-Dojo/PrivateBox/contents/notes/20260222T153045-a1b2c3d4.md \
+  --jq '.content' | base64 -d
+
+# Read the backlinks index
+gh api repos/Randroids-Dojo/PrivateBox/contents/index/backlinks.json \
+  --jq '.content' | base64 -d | jq '.'
+
+# Read the clusters index
+gh api repos/Randroids-Dojo/PrivateBox/contents/index/clusters.json \
+  --jq '.content' | base64 -d | jq '.'
+
+# Read the tensions index
+gh api repos/Randroids-Dojo/PrivateBox/contents/index/tensions.json \
+  --jq '.content' | base64 -d | jq '.'
+```
+
+### Search notes by content
+
+```bash
+# Search PrivateBox notes for a keyword (uses GitHub code search)
+gh api "search/code?q=<keyword>+repo:Randroids-Dojo/PrivateBox+path:notes" \
+  --jq '.items[].path'
+
+# Or clone locally for fast full-text search
+gh repo clone Randroids-Dojo/PrivateBox /tmp/privatebox
+grep -r "keyword" /tmp/privatebox/notes/ --include="*.md" -l
+```
+
+### Find notes by tag
+
+```bash
+gh api "search/code?q=tags+keyword+repo:Randroids-Dojo/PrivateBox+path:notes" \
+  --jq '.items[].path'
+```
+
+---
+
+## Workflows
+
+### Capture an idea
+
+1. Write the atomic idea as a single focused thought.
+2. POST to `/api/add-note` with the content.
+3. Note the returned `noteId` and `linkedNotes` to see what concepts it connects to.
+4. Optionally run `/api/link-pass` afterward if adding many notes in bulk.
+
+### Browse and explore
+
+1. List notes with `gh api repos/Randroids-Dojo/PrivateBox/contents/notes`.
+2. Read individual notes by ID.
+3. Follow `links` in frontmatter to explore connected ideas.
+4. Use the clusters index to browse thematic groups.
+5. Use the tensions index to identify areas of conceptual conflict worth investigating.
+
+### Run a full analysis cycle
+
+After adding a batch of notes or to refresh the graph:
+
+```bash
+# Step 1: Recompute links
+curl -s -X POST http://localhost:3000/api/link-pass \
+  -H "Authorization: Bearer $SLIPBOX_API_KEY"
+
+# Step 2: Recluster
+curl -s -X POST http://localhost:3000/api/cluster-pass \
+  -H "Authorization: Bearer $SLIPBOX_API_KEY"
+
+# Step 3: Detect tensions
+curl -s -X POST http://localhost:3000/api/tension-pass \
+  -H "Authorization: Bearer $SLIPBOX_API_KEY"
+```
+
+### Start the local service
+
+```bash
+cd /Users/randroid/Documents/Dev/SlipBox
+npm run dev
+# Service available at http://localhost:3000
+```

--- a/plugins/slipbox/commands/slipbox.md
+++ b/plugins/slipbox/commands/slipbox.md
@@ -1,0 +1,34 @@
+# SlipBox
+
+Interact with the SlipBox semantic knowledge engine and read notes from PrivateBox.
+
+**Service**: `http://localhost:3000` (run `cd /Users/randroid/Documents/Dev/SlipBox && npm run dev`)
+**Notes repo**: https://github.com/Randroids-Dojo/PrivateBox
+**Auth**: `Authorization: Bearer $SLIPBOX_API_KEY`
+
+## Quick Reference
+
+```bash
+# Health check
+curl -s http://localhost:3000/api/health
+
+# Add a note
+curl -s -X POST http://localhost:3000/api/add-note \
+  -H "Authorization: Bearer $SLIPBOX_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "Atomic idea."}'
+
+# Read a note from PrivateBox
+gh api repos/Randroids-Dojo/PrivateBox/contents/notes/<noteId>.md \
+  --jq '.content' | base64 -d
+
+# List all notes
+gh api repos/Randroids-Dojo/PrivateBox/contents/notes --jq '.[].name'
+
+# Run full analysis (link → cluster → tension)
+curl -s -X POST http://localhost:3000/api/link-pass -H "Authorization: Bearer $SLIPBOX_API_KEY"
+curl -s -X POST http://localhost:3000/api/cluster-pass -H "Authorization: Bearer $SLIPBOX_API_KEY"
+curl -s -X POST http://localhost:3000/api/tension-pass -H "Authorization: Bearer $SLIPBOX_API_KEY"
+```
+
+For full documentation, read `${CLAUDE_PLUGIN_ROOT}/SKILL.md`.


### PR DESCRIPTION
## Summary

- Adds `plugins/slipbox/` skill for interacting with the local SlipBox semantic knowledge engine and reading notes from the PrivateBox GitHub repository
- Covers all four API endpoints (`add-note`, `link-pass`, `cluster-pass`, `tension-pass`) with request/response examples
- Documents note format, PrivateBox index files, and `gh` CLI commands for reading and searching notes
- Includes workflows for capturing ideas, browsing the knowledge graph, and running full analysis cycles
- Registers the skill in `marketplace.json` and updates `README.md` with installation and usage for Claude Code and Codex

## Test plan

- [ ] Confirm `plugins/slipbox/SKILL.md` loads correctly as a Codex skill (`$slipbox`)
- [ ] Confirm `plugins/slipbox/commands/slipbox.md` works as a Claude Code slash command (`/slipbox:slipbox`)
- [ ] Verify `npx skills add ... --skill slipbox` installs from this repo
- [ ] Smoke-test API calls against local SlipBox service (`npm run dev` in `/Users/randroid/Documents/Dev/SlipBox`)
- [ ] Verify `gh api` note-reading commands work against PrivateBox