### PR TITLE
feat: improve skill review scores across all five plugins

### DIFF
--- a/plugins/godot/SKILL.md
+++ b/plugins/godot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: godot
-description: Develop, test, build, and deploy Godot 4.x games. Use when working with Godot Engine, GDScript, GdUnit4 testing, PlayGodot automation, or exporting games to web/desktop. Covers CI/CD pipelines and deployment to Vercel/GitHub Pages/itch.io.
+description: "Develop, test, build, and deploy Godot 4.x games. Use when working with Godot Engine, GDScript, GdUnit4 testing, PlayGodot automation, or exporting games to web/desktop. Covers CI/CD pipelines and deployment to Vercel/GitHub Pages/itch.io."
 ---
 
 # Godot Skill
@@ -130,51 +130,7 @@ godot --headless --path . -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd \
   --run-tests --report-directory ./reports
 ```
 
-### GdUnit4 Assertions
-
-```gdscript
-# Values
-assert_that(value).is_equal(expected)
-assert_that(value).is_not_null()
-assert_that(condition).is_true()
-
-# Numbers
-assert_that(number).is_greater(5)
-assert_that(number).is_between(1, 100)
-
-# Strings
-assert_that(text).contains("expected")
-assert_that(text).starts_with("prefix")
-
-# Arrays
-assert_that(array).contains(element)
-assert_that(array).has_size(5)
-
-# Signals
-await assert_signal(node).is_emitted("signal_name")
-```
-
-### Scene Runner Input API
-
-```gdscript
-# Mouse
-runner.set_mouse_position(Vector2(100, 100))
-runner.simulate_mouse_button_pressed(MOUSE_BUTTON_LEFT)
-runner.simulate_mouse_button_released(MOUSE_BUTTON_LEFT)
-
-# Keyboard
-runner.simulate_key_pressed(KEY_SPACE)
-runner.simulate_key_pressed(KEY_S, false, true)  # Ctrl+S
-
-# Input actions
-runner.simulate_action_pressed("jump")
-runner.simulate_action_released("jump")
-
-# Waiting
-await runner.await_input_processed()
-await runner.await_idle_frame()
-await runner.await_signal("game_over", [], 5000)
-```
+For the full GdUnit4 assertions API, see `references/assertions.md`. For Scene Runner input simulation, see `references/scene-runner.md`.
 
 ---
 
@@ -266,66 +222,7 @@ pytest tests/ -v
 pytest tests/test_game.py::test_clicking_cell -v
 ```
 
-### PlayGodot API
-
-```python
-# Node interaction
-node = await game.get_node("/root/Game")
-await game.wait_for_node("/root/Game", timeout=10.0)
-exists = await game.node_exists("/root/Game")
-result = await game.call("/root/Node", "method", [arg1, arg2])
-value = await game.get_property("/root/Node", "property")
-await game.set_property("/root/Node", "property", value)
-
-# Node queries
-paths = await game.query_nodes("*Button*")
-count = await game.count_nodes("*Label*")
-
-# Mouse input
-await game.click("/root/Button")
-await game.click(300, 200)
-await game.double_click("/root/Button")
-await game.right_click(100, 100)
-await game.drag("/root/Item", "/root/Slot")
-
-# Keyboard input
-await game.press_key("space")
-await game.press_key("ctrl+s")
-await game.type_text("hello")
-
-# Input actions
-await game.press_action("jump")
-await game.hold_action("sprint", 2.0)
-
-# Touch input
-await game.tap(300, 200)
-await game.swipe(100, 100, 400, 100)
-await game.pinch((200, 200), 0.5)
-
-# Screenshots
-png_bytes = await game.screenshot()
-await game.screenshot("/tmp/screenshot.png")
-similarity = await game.compare_screenshot("expected.png")
-await game.assert_screenshot("reference.png", threshold=0.99)
-
-# Scene management
-scene = await game.get_current_scene()
-await game.change_scene("res://scenes/level2.tscn")
-await game.reload_scene()
-
-# Game state
-await game.pause()
-await game.unpause()
-is_paused = await game.is_paused()
-await game.set_time_scale(0.5)
-scale = await game.get_time_scale()
-
-# Waiting
-await game.wait_for_node("/root/Game/SpawnedEnemy", timeout=5.0)
-await game.wait_for_visible("/root/Game/UI/GameOverPanel", timeout=10.0)
-await game.wait_for_signal("game_over")
-await game.wait_for_signal("health_changed", source="/root/Game/Player")
-```
+For the full PlayGodot API (node queries, mouse/keyboard/touch input, screenshots, scene management, game state), see `references/playgodot.md`.
 
 ---
 
@@ -336,6 +233,9 @@ await game.wait_for_signal("health_changed", source="/root/Game/Player")
 ```bash
 # Requires export_presets.cfg with Web preset
 godot --headless --export-release "Web" ./build/index.html
+
+# Verify the export succeeded
+test -f ./build/index.html && echo "Export OK" || echo "Export FAILED — check export_presets.cfg and installed templates"
 ```
 
 ### Export Preset (export_presets.cfg)
@@ -353,6 +253,9 @@ export_path="build/index.html"
 ```bash
 npm i -g vercel
 vercel deploy ./build --prod
+
+# Verify deployment (replace URL with Vercel output)
+curl -s -o /dev/null -w "%{http_code}" https://your-project.vercel.app | grep -q 200 && echo "Deploy OK"
 ```
 
 ---

--- a/plugins/loop/SKILL.md
+++ b/plugins/loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: loop
-description: Runs an autonomous development loop with research and implementation modes. Use when orchestrating iterative research and implementation cycles with dots-based task tracking and git workflow automation.
+description: "Automate iterative development by researching solutions then writing code across multiple cycles. Use when you want hands-off coding, automated development loops, iterative research-then-implement workflows, or autonomous task completion with git commits and task tracking."
 metadata:
   claude_triggers: "/loop, /randroid, /randroid-loop"
   claude_hooks: "Stop: hooks/stop-hook.sh"
@@ -8,238 +8,89 @@ metadata:
 
 # Loop
 
-A self-sustaining development loop with two modes: **Researcher** and **Implementor**.
+A self-sustaining development loop with two modes: **Researcher** (explore, plan, create specs) and **Implementor** (write code, tests, docs from specs). Each iteration creates git commits, tracks progress via Dots, and optionally opens PRs.
 
 ## Prerequisites
 
-**Full permissions required.** The loop runs autonomously and needs unrestricted access.
+**Full permissions required.** The loop runs autonomously.
 
-### Claude Code
-```bash
-claude --dangerously-skip-permissions
-```
-
-### Codex
-The script automatically uses `--yolo` mode (no sandbox, no prompts).
+| Agent | Command |
+|-------|---------|
+| Claude Code | `claude --dangerously-skip-permissions` |
+| Codex | Automatically uses `--yolo` mode |
 
 ## Startup Flow
 
-When this skill is invoked, ask the user FOUR questions using AskUserQuestion, then one text prompt:
+Ask the user these questions via AskUserQuestion (Q1–Q4), then a text prompt (Q5):
 
-### Question 1: Mode (AskUserQuestion)
-- **Question**: "Which mode would you like to run?"
-- **Options**:
-  1. `Research` - Explore, investigate, and plan. Creates specs for implementation.
-  2. `Implement` - Execute on specs. Write code, tests, and documentation.
+| # | Question | Options |
+|---|----------|---------|
+| 1 | Mode | `Research` (explore/plan/spec) · `Implement` (code/test/docs) |
+| 2 | Git workflow | `Push` (default) · `Commit only` · `Open PR` · `PR and merge` |
+| 3 | Context | `Fresh context` (default, recommended) · `Keep context` |
+| 4 | Directions | `None` · mode-specific presets · `Other` (free-text) |
+| 5 | Iterations (text prompt) | Number → exact count · `inf` → infinite · `comp` → until complete |
 
-### Question 2: Git Workflow (AskUserQuestion)
-- **Question**: "What should happen after each task?"
-- **Options**:
-  - `Push` - Commit and push to current branch (default)
-  - `Commit only` - Commit locally, no push
-  - `Open PR` - Open PR, wait for CI (no merge)
-  - `PR and merge` - Open PR, wait for CI, then auto-merge
-
-### Question 3: Context Management (AskUserQuestion)
-- **Question**: "Should each iteration start with fresh context?"
-- **Options**:
-  - `Fresh context` - Clear context between iterations (default, recommended)
-  - `Keep context` - Maintain conversation history across iterations
-
-### Question 4: Directions (AskUserQuestion - optional)
-- **Question**: "Any specific directions for this run?"
-- **Options** (mode-aware, user can select "Other" for custom):
-  - `None` - No specific directions, work autonomously
-  - For Research mode:
-    - `Focus on specs` - Review and improve existing implementation specs
-    - `Explore dependencies` - Research external libraries and frameworks
-  - For Implement mode:
-    - `Fix issues first` - Prioritize fixing build errors and warnings
-    - `Skip tests` - Focus on implementation, skip test writing for now
-
-If user selects "Other", they can provide custom directions like:
-- "Focus on authentication patterns"
-- "Search Apple developer docs for NSPanel"
-- "Prioritize the archive feature"
-- "Redo the task list with proper SwiftUI patterns"
-
-The agent interprets directions intelligently (creating dots, modifying tasks, updating docs, changing priorities, etc.).
-
-### Question 5: Iterations (Text prompt - NOT AskUserQuestion)
-After the AskUserQuestion completes, ask:
-> "How many iterations? Enter a number, 'inf' for infinite, or 'comp' for until complete:"
-
-Parse the response:
-- Number (e.g., "2", "5", "10") → exact iteration count
-- "inf", "infinite", "-1" → infinite mode (-1)
-- "comp", "complete", "0" → until complete mode (0)
-
-**Key distinction:**
-- **Infinite / N iterations**: Completion promise is IGNORED. Loop continues for re-analysis and improvement.
-- **Until complete**: Only mode where completion promise stops the loop.
+**Key distinction:** In infinite/N-iteration modes the completion promise is ignored. Only "until complete" mode stops on the completion promise.
 
 After collecting answers:
-1. Initialize loop state by running: `./scripts/setup-loop.sh <mode> --iterations <N> --git-workflow <workflow> [--fresh-context] [--directions "..."]`
-   - Iterations: -1=infinite, 0=until complete, N=exact count
-   - Workflow: commit/push/pr/pr-merge
-   - Directions: optional user guidance for the agent
-2. Build the prompt by combining mode-specific + shared content:
-   - Read `<mode>-loop.md` (mode-specific sections)
-   - Read `loop-shared.md` (common sections)
-   - Concatenate: mode-specific + shared
-3. Begin execution based on context mode:
 
-**Fresh context mode (default):**
-You are the orchestrator. Run this loop in the main conversation:
+1. **Initialize**: Run `./scripts/setup-loop.sh <mode> --iterations <N> --git-workflow <workflow> [--fresh-context] [--directions "..."]`
+2. **Verify**: Confirm setup-loop.sh exits 0. If it fails, report the error and stop.
+3. **Build prompt**: Read `<mode>-loop.md` + `loop-shared.md`, concatenate them. Append user directions if provided.
+4. **Execute** based on context mode (see below).
 
-```
-iteration = 0
-PROMPT = contents of <mode>-loop.md + "\n\n" + contents of loop-shared.md
-DIRECTIONS = user's directions (if provided)
+### Fresh Context Mode (default)
 
-# Exponential backoff for infinite mode
-MIN_DELAY = 5        # seconds
-current_delay = MIN_DELAY
+You are the orchestrator. For each iteration, spawn a Task subagent with the built prompt:
 
-# If directions were provided, append them to the prompt
-if DIRECTIONS:
-    PROMPT = PROMPT + "\n\n## User Directions\n\n" + DIRECTIONS
+- **Until complete** (`iterations=0`): Stop when result contains `RANDROID_LOOP_COMPLETE`.
+- **Exact N** (`iterations>0`): Stop after N iterations.
+- **Infinite** (`iterations=-1`): Never stop on completion promise. Apply exponential backoff (starting 5s, doubling) when idle; reset on meaningful work.
 
-LOOP:
-    iteration += 1
-    print "=== Iteration {iteration} ==="
+**CRITICAL**: After each Task returns, YOU must check termination conditions and spawn the next iteration. Do not stop just because one Task finished.
 
-    result = Task(prompt=PROMPT, subagent_type="general-purpose")
+### Keep Context Mode
 
-    # Check termination conditions
-    if iterations == 0:  # "until complete" mode
-        if result contains "RANDROID_LOOP_COMPLETE":
-            print "Loop complete (promise found after {iteration} iterations)"
-            EXIT LOOP
-    elif iterations > 0:  # exact N iterations mode
-        if iteration >= iterations:
-            print "Completed {iteration} iterations"
-            EXIT LOOP
-    # iterations == -1 means infinite, continues below
-
-    # Exponential backoff for infinite mode when no work done
-    if iterations == -1:  # infinite mode
-        if result contains "RANDROID_LOOP_COMPLETE":
-            print "No work this iteration, backing off for {current_delay}s..."
-            sleep(current_delay)
-            current_delay = current_delay * 2  # No max cap
-        else:
-            # Meaningful work done, reset backoff
-            current_delay = MIN_DELAY
-
-    GOTO LOOP
-```
-
-**CRITICAL**: After each Task returns, YOU (the orchestrator) must:
-1. Check the result for the completion promise
-2. Check if iteration limit reached
-3. If neither → spawn another Task for the next iteration
-4. Do NOT stop just because one Task finished
-
-**Keep context mode:**
-Run the loop directly in the current conversation. The stop hook will intercept exit and continue looping with accumulated context.
+Run the loop in the current conversation. The stop hook intercepts exit and continues looping with accumulated context.
 
 ## Usage
 
-### Interactive (Recommended)
+```bash
+/loop                          # Interactive — prompts for all options
+/loop research                 # Research mode, prompts for iterations
+/loop implement --iterations 5 # Implement mode, 5 iterations
+/loop implement --open-pr      # Open PR after each task
+/loop implement --pr-and-merge # PR with auto-merge
+/loop implement --keep-context # Maintain conversation history
 ```
-/loop
-```
-Prompts for mode, iterations, and optional directions.
 
 Aliases: `/randroid`, `/randroid-loop`
 
-### Direct (Skip Questions)
-- `/loop research` - Research mode, prompts for iterations
-- `/loop implement` - Implement mode, prompts for iterations
-- `/loop research --loop` - Research mode, infinite (ignores completion)
-- `/loop research --until-complete` - Research mode, stops on completion
-- `/loop implement --iterations 5` - Implement mode, exactly 5 iterations
-- `/loop implement --open-pr` - Open PR workflow
-- `/loop implement --pr-and-merge` - PR with auto-merge workflow
-- `/loop implement --commit-only` - Local commits only
-- `/loop implement --keep-context` - Keep conversation context (no fresh start)
-- `/loop implement --iterations 5 --open-pr` - Combine options
-
-### With Directions
-You can provide guidance for the agent. When prompted for directions:
-- Select a preset option (mode-specific), or
-- Select "Other" and type custom directions like:
-  - "Focus on authentication patterns"
-  - "Prioritize the archive feature, skip tests for now"
-
-Directions can include:
-- Topics to research or questions to answer
-- Priorities for which tasks to work on
-- Specific implementation guidance
-- Requests to redo or improve previous work
-- Scope changes (add/remove/modify tasks)
-
 ### Codex (External Script)
-```bash
-# From terminal (outside Codex)
-./scripts/randroid-loop.sh
-# Interactive prompts for mode, iterations, and git workflow
-# Note: Wrapper always uses fresh context (each iteration is a new codex exec)
 
-# Direct invocation:
-./scripts/randroid-loop.sh research -1           # infinite
-./scripts/randroid-loop.sh research 0            # until complete
-./scripts/randroid-loop.sh implement 5           # exactly 5 iterations
-./scripts/randroid-loop.sh implement 5 pr        # 5 iterations, open PR
-./scripts/randroid-loop.sh implement 0 pr-merge  # until complete, PR + merge
+```bash
+./scripts/randroid-loop.sh                        # Interactive
+./scripts/randroid-loop.sh research -1            # Infinite research
+./scripts/randroid-loop.sh implement 5 pr         # 5 iterations, open PR
+./scripts/randroid-loop.sh implement 0 pr-merge   # Until complete, PR + merge
 ```
 
 ## Modes
 
 ### Research Mode
-The researcher explores, investigates, and plans. It:
-- Creates `research:` prefixed dots to track its own exploration
-- Creates `implement:` prefixed dots as deliverables for the implementor
-- Does NOT write production code
-- Outputs findings, decisions, and clear implementation specs
+Creates `research:` dots to track exploration and `implement:` dots as deliverables for the implementor. Does NOT write production code — outputs findings, decisions, and implementation specs.
 
 ### Implementor Mode
-The implementor executes. It:
-- Pulls from ready `implement:` dots
-- Writes code, tests, and documentation
-- Creates new `implement:` dots if scope expands
-- Creates `research:` dots if blocked by unknowns (for next research cycle)
+Pulls from ready `implement:` dots. Writes code, tests, and documentation. Creates new `implement:` or `research:` dots as scope expands or unknowns surface.
 
 ## Loop Mechanics
 
-### Fresh Context Each Iteration
-Each loop iteration starts with **fresh conversational context**. Only the filesystem persists:
-- Modified files
-- Git history and commits
-- Dots system state
-- Research/implementation artifacts
-
-This prevents context bloat and allows the agent to approach each iteration with clarity.
-
-### What Persists
-- All file changes from previous iterations
-- Git commits and history
-- `.dots/` task state
-- Any written documentation or specs
-
-### What Resets
-- Conversation history
-- In-memory state
-- Token usage (fresh budget each iteration)
+Each iteration starts with **fresh context** (default). Only the filesystem persists: modified files, git history, `.dots/` task state, and written artifacts. Conversation history and token budget reset.
 
 ## Loop Termination
 
-Output `<promise>RANDROID_LOOP_COMPLETE</promise>` when:
-- No more ready tasks for your mode
-- All work is committed and pushed
-
-The loop also stops when `--iterations N` limit is reached.
+Output `<promise>RANDROID_LOOP_COMPLETE</promise>` when no more ready tasks exist for your mode and all work is committed. The loop also stops when `--iterations N` limit is reached.
 
 ## Architecture
 

--- a/plugins/slipbox/SKILL.md
+++ b/plugins/slipbox/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: slipbox
 description: "Interact with the SlipBox semantic knowledge engine and read notes from PrivateBox. Use when capturing ideas, searching notes, browsing your knowledge graph, or running semantic analysis passes (link, cluster, tension)."
-compatibility: Requires SLIPBOX_API_KEY, SLIPBOX_URL, and SLIPBOX_PRIVATEBOX_REPO env vars. Reading PrivateBox notes requires GITHUB_TOKEN or the gh CLI.
+compatibility: "Requires SLIPBOX_API_KEY, SLIPBOX_URL, and SLIPBOX_PRIVATEBOX_REPO env vars. Reading PrivateBox notes requires GITHUB_TOKEN or the gh CLI."
 ---
 
 # SlipBox Skill
@@ -70,48 +70,9 @@ All other configuration (OpenAI, GitHub, PrivateBox) lives on the deployed Verce
 
 ---
 
-## Quick Reference
+## API Reference
 
 All API calls require: `Authorization: Bearer $SLIPBOX_API_KEY`
-
-```bash
-# Health check
-curl -sL "$SLIPBOX_URL/api/health"
-
-# Add a note
-curl -sL -X POST "$SLIPBOX_URL/api/add-note" \
-  -H "Authorization: Bearer $SLIPBOX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"content": "Atomic idea goes here."}'
-
-# Add a typed note (type: "meta" or "hypothesis")
-curl -sL -X POST "$SLIPBOX_URL/api/add-note" \
-  -H "Authorization: Bearer $SLIPBOX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"content": "## Cluster: ...", "type": "meta"}'
-
-# Re-link all notes (recompute similarity links)
-curl -sL -X POST "$SLIPBOX_URL/api/link-pass" \
-  -H "Authorization: Bearer $SLIPBOX_API_KEY"
-
-# Cluster notes into thematic groups
-curl -sL -X POST "$SLIPBOX_URL/api/cluster-pass" \
-  -H "Authorization: Bearer $SLIPBOX_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"k": 5}'
-
-# Detect conceptual tensions (contradictions within clusters)
-curl -sL -X POST "$SLIPBOX_URL/api/tension-pass" \
-  -H "Authorization: Bearer $SLIPBOX_API_KEY"
-
-# Fetch theme data (clusters + note content + tensions) for agent synthesis
-curl -sL "$SLIPBOX_URL/api/theme-data" \
-  -H "Authorization: Bearer $SLIPBOX_API_KEY"
-```
-
----
-
-## API Reference
 
 ### POST /api/add-note
 

--- a/plugins/task-tracking-dots/SKILL.md
+++ b/plugins/task-tracking-dots/SKILL.md
@@ -1,19 +1,12 @@
 ---
 name: task-tracking-dots
-description: Manages Dots task tracking with the dot CLI, dependencies, and completion reasons. Use when tracking work items across sessions or coordinating task dependencies.
-compatibility: Requires the dot CLI available in the session environment.
+description: "Create, list, complete, and block tasks using the Dots CLI with priorities and dependencies. Use when tracking todos, managing a task list, recording progress across sessions, setting task blockers, or coordinating dependent work items."
+compatibility: "Requires the dot CLI available in the session environment."
 ---
 
 # Task Tracking with Dots
 
-Dots is a lightweight task tracker for managing work across sessions. Use the `dot` CLI to track work items, dependencies, and completion reasons.
-
-## When to use this skill
-
-Use this skill when you need to:
-- Track work items across sessions
-- Manage dependencies between tasks
-- Record completion reasons for auditability
+Dots is a lightweight task tracker for managing work across sessions. Use the `dot` CLI to create tasks, list pending items, mark tasks complete with reasons, set blockers, and track dependencies.
 
 ## Preflight: ensure dot is installed
 

--- a/plugins/unreal/SKILL.md
+++ b/plugins/unreal/SKILL.md
@@ -1,19 +1,24 @@
 ---
 name: unreal
-description: Develop, test, and automate Unreal Engine 5.x projects (WIP). Covers PlayUnreal automation, Remote Control API, Automation Driver, and CI-friendly E2E flows.
+description: "Automate Unreal Engine 5.x editor workflows via PlayUnreal, send Remote Control API commands, write Automation Driver test scripts, and configure CI pipelines for E2E testing. Use when working with UE5 automation, Unreal Engine testing, Remote Control API integration, editor scripting, or .uproject CI pipelines."
 ---
 
 # Unreal Skill (WIP)
 
-Automate Unreal Engine 5.x with PlayUnreal style external control.
+Automate Unreal Engine 5.x with PlayUnreal-style external control via the native Remote Control API and Automation Driver.
 
-Status: WIP. PlayUnreal repo: https://github.com/Randroids-Dojo/PlayUnreal
+**Status**: Work in progress — Quick Reference commands work today; the PlayUnreal Python API below is the target interface (not yet released).
+
+PlayUnreal repo: https://github.com/Randroids-Dojo/PlayUnreal
 
 ## Quick Reference
 
 ```bash
 # Launch editor with Remote Control enabled
 UnrealEditor "/path/MyGame.uproject" -ExecCmds="WebControl.StartServer"
+
+# Verify Remote Control is responding (health check)
+curl -s http://127.0.0.1:30010/remote/info | jq .
 
 # Packaged build (enable Remote Control)
 MyGame.exe -RCWebControlEnable -RCWebInterfaceEnable -ExecCmds="WebControl.StartServer"
@@ -26,19 +31,23 @@ python plugins/unreal/scripts/rc_wait_ready.py \
 
 ## Setup Checklist
 
-- Enable Remote Control and Automation Driver plugins.
-- Add the PlayUnrealAutomation plugin to the project.
-- Place the PlayUnreal driver actor or subsystem in the map.
-- Tag key UMG widgets with automation IDs for stable selectors.
-- Keep Remote Control on LAN/VPN only.
+1. Enable **Remote Control API** plugin: Edit → Plugins → search "Remote Control API" → enable → restart editor.
+2. Enable **Automation Driver** plugin: Edit → Plugins → search "Automation Driver" → enable → restart editor.
+3. Add the **PlayUnrealAutomation** plugin to your `.uproject` `Plugins` array.
+4. Place the PlayUnreal driver actor or subsystem in the map.
+5. Tag key UMG widgets with automation IDs (`Slot Name` in widget details) for stable selectors.
+6. **Verify**: Launch the editor with Remote Control, then run `curl -s http://127.0.0.1:30010/remote/info | jq .` — confirm a JSON response with engine version.
+7. Keep Remote Control on LAN/VPN only (not exposed to the internet).
 
 ## Selector Strategy
 
-- `id=StartButton` maps to Automation Driver `By::Id`.
-- `path=#Menu//Start/<SButton>` maps to `By::Path`.
-- `text="Start"` can be implemented via custom traversal if needed.
+| Selector | Maps to | Example |
+|----------|---------|---------|
+| `id=StartButton` | `By::Id` | Widget with automation ID "StartButton" |
+| `path=#Menu//Start/<SButton>` | `By::Path` | Hierarchy path traversal |
+| `text="Start"` | Custom traversal | Finds widget by displayed text |
 
-## PlayUnreal Python (target API)
+## PlayUnreal Python (target API — not yet released)
 
 ```python
 from playunreal import Unreal
@@ -56,12 +65,12 @@ async with Unreal.launch(
 
 ## Packaged Builds
 
-- Use `-RCWebControlEnable -RCWebInterfaceEnable`.
+- Use `-RCWebControlEnable -RCWebInterfaceEnable` flags.
 - Ensure presets and assets are staged if using Remote Control presets.
 
 ## References
 
-- `references/remote-control.md`
-- `references/automation-driver.md`
-- `references/umg-automation.md`
-- `references/playunreal.md`
+- `references/remote-control.md` — Remote Control API details
+- `references/automation-driver.md` — Automation Driver guide
+- `references/umg-automation.md` — UMG widget automation
+- `references/playunreal.md` — PlayUnreal automation guide


### PR DESCRIPTION
Hey @Randroids-Dojo 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="910" alt="image" src="https://github.com/user-attachments/assets/bfe36ce3-2d3f-412c-992a-5bcd71c1ce7b" />


Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| loop | 57% | 86% | +29% |
| unreal | 65% | 83% | +18% |
| task-tracking-dots | 81% | 97% | +16% |
| godot | 86% | 89% | +3% |
| slipbox | 86% | 86% | 0% |

This PR is intentionally scoped to all five skills in the repo — kept reviewable as a single contribution.

<details>
<summary>Changes made</summary>

**loop** (+29%):
- Rewrote description with natural trigger terms ("hands-off coding", "automated development loops") and explicit "Use when" clause
- Condensed verbose startup flow from individual subsections into a compact table
- Replaced pseudocode orchestration loop with concise behavioral description
- Added setup-loop.sh exit code verification step
- Consolidated redundant usage examples

**unreal** (+18%):
- Added explicit "Use when" clause with common trigger terms (UE5, editor scripting, .uproject)
- Made Setup Checklist actionable with specific Editor menu paths and plugin names
- Added Remote Control health check verification step (curl)
- Clearly labeled PlayUnreal Python API as "not yet released" vs working Quick Reference commands
- Added selector strategy comparison table

**task-tracking-dots** (+16%):
- Expanded description with concrete actions (create, list, complete, block) and natural trigger terms (todos, task list, progress)
- Removed redundant "When to use this skill" section that duplicated the description
- Quoted description and compatibility fields in frontmatter

**godot** (+3%):
- Moved inline GdUnit4 assertions and Scene Runner Input API to reference file pointers (references/assertions.md, references/scene-runner.md)
- Moved inline PlayGodot API catalog to reference file pointer (references/playgodot.md)
- Added build export validation step (test -f) and deployment verification (curl health check)
- Quoted description in frontmatter

**slipbox** (0%):
- Removed duplicate Quick Reference section (API Reference already contains the same curl commands with more detail)
- Quoted compatibility field in frontmatter

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
