### PR TITLE
spiral: reference CodeRabbit instead of Copilot in templates

### DIFF
--- a/plugins/spiral/templates/AGENTS.md
+++ b/plugins/spiral/templates/AGENTS.md
@@ -89,7 +89,7 @@ For every slice:
 6. Update `docs/PROGRESS_LOG.md`, `docs/GDD_COVERAGE.json`, `docs/OPEN_QUESTIONS.md`, `docs/FOLLOWUPS.md`, and the GDD section when the work changes them.
 7. Run the local verification suite. At minimum: dash checks, `git diff --check`, type-check, relevant unit tests, broader checks when warranted.
 8. Open a PR.
-9. Inspect all PR review comments, including inline and threaded comments from Copilot or other review bots.
+9. Inspect all PR review comments, including inline and threaded comments from CodeRabbit or other review bots.
 10. Fix actionable review comments, reply in-thread when the platform supports it, resolve threads when resolved.
 11. After every push to the PR branch, wait for any configured bot reviewer to finish its review pass. The wait is settled only when all required checks are green AND at least 60 seconds have passed since the latest PR branch push or latest bot review activity, whichever is later. Re-inspect reviews and review threads after the settled wait.
 12. Wait for CI and the preview deploy to pass.

--- a/plugins/spiral/templates/WORKING_AGREEMENT.md
+++ b/plugins/spiral/templates/WORKING_AGREEMENT.md
@@ -27,7 +27,7 @@ Every PR must include:
 After opening a PR:
 
 - Read flat comments, reviews, and threaded inline comments.
-- Treat Copilot or bot review comments as actionable unless clearly incorrect.
+- Treat CodeRabbit or bot review comments as actionable unless clearly incorrect.
 - Fix valid comments and push followup commits.
 - After every followup push, wait for any configured bot reviewer to finish reviewing that pushed commit.
 - The bot review wait is settled only when all required checks are green AND at least 60 seconds have passed since the latest PR branch push or latest bot review activity, whichever is later.


### PR DESCRIPTION
## Summary
- Switched the spiral templates (`AGENTS.md`, `WORKING_AGREEMENT.md`) to reference CodeRabbit instead of Copilot for PR review automation, since Copilot's monthly review limit was hit.

## Test plan
- [ ] Confirm spiral template wording reads naturally with CodeRabbit substituted in.