### PR TITLE
spiral-html: HTML-first variant of the spiral skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,6 +33,11 @@
       "name": "spiral",
       "source": "./plugins/spiral",
       "description": "Bootstrap and audit the structural-discipline scaffold (GDD tree, coverage ledger, progress log, open questions, followups, playtest gate) that takes a vision into a delivered system through small iterations whose state lives in git, not the agent's head. Pairs with randroid-loop and task-tracking-dots. Cross-tool: works with Claude Code via .claude/rules/ and Codex via per-directory AGENTS.md symlinks."
+    },
+    {
+      "name": "spiral-html",
+      "source": "./plugins/spiral-html",
+      "description": "HTML-first variant of the spiral skill. Same structural-discipline scaffold (GDD tree, coverage ledger, progress log, open questions, followups, playtest gate) authored in HTML rather than Markdown. Ledgers use semantic data-* attributes for unambiguous agent reads. Ships AGENTS.md / CLAUDE.md shims pointing at AGENTS.html so Codex and Claude Code still land on the contract."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A dual-format skills repository for **Claude Code**, **Codex CLI**, and **OpenCo
 | **godot** | Develop, test, build, and deploy Godot 4.x games |
 | **unreal** | Develop, test, and automate Unreal Engine 5.x projects (WIP). PlayUnreal: https://github.com/Randroids-Dojo/PlayUnreal |
 | **slipbox** | Interact with the SlipBox semantic knowledge engine and read notes from PrivateBox |
+| **spiral** | Bootstrap and audit the structural-discipline scaffold (Markdown ledgers) used by long-running autonomous PR loops |
+| **spiral-html** | HTML-first variant of spiral. Same scaffold and audit checks, ledgers authored as semantic HTML with `data-*` ids |
 
 ## Installation
 
@@ -61,6 +63,7 @@ $skill-installer https://github.com/Randroids-Dojo/skills/tree/main/plugins/godo
 $skill-installer https://github.com/Randroids-Dojo/skills/tree/main/plugins/unreal
 $skill-installer https://github.com/Randroids-Dojo/skills/tree/main/plugins/slipbox
 $skill-installer https://github.com/Randroids-Dojo/skills/tree/main/plugins/spiral
+$skill-installer https://github.com/Randroids-Dojo/skills/tree/main/plugins/spiral-html
 ```
 
 Or clone for all skills at once:
@@ -78,6 +81,7 @@ ln -s ~/.agents/skills/randroids-dojo/plugins/godot ~/.agents/skills/godot
 ln -s ~/.agents/skills/randroids-dojo/plugins/unreal ~/.agents/skills/unreal
 ln -s ~/.agents/skills/randroids-dojo/plugins/slipbox ~/.agents/skills/slipbox
 ln -s ~/.agents/skills/randroids-dojo/plugins/spiral ~/.agents/skills/spiral
+ln -s ~/.agents/skills/randroids-dojo/plugins/spiral-html ~/.agents/skills/spiral-html
 ```
 
 Note: Codex 2026 reads skills from `~/.agents/skills/` (the universal "Agent Skills" path), not `~/.codex/skills/`. The `npx skills` CLI also targets `~/.agents/skills/` for Codex.
@@ -94,6 +98,7 @@ Install from the marketplace:
 /plugin install unreal
 /plugin install slipbox
 /plugin install spiral
+/plugin install spiral-html
 ```
 
 ### Install locations (Skills CLI)
@@ -119,6 +124,7 @@ $godot              # Invoke godot skill
 $unreal             # Invoke unreal skill
 $slipbox            # Invoke slipbox skill
 $spiral             # Bootstrap or audit a project scaffold
+$spiral-html        # HTML-first variant of spiral
 ```
 
 ### Claude Code
@@ -130,6 +136,7 @@ $spiral             # Bootstrap or audit a project scaffold
 /unreal:unreal      # Unreal development assistance
 /slipbox:slipbox    # SlipBox knowledge engine
 /spiral             # Bootstrap or audit a project scaffold (/spiral init, /spiral audit)
+/spiral-html        # HTML-first variant (/spiral-html init, /spiral-html audit)
 ```
 
 ## Repository Structure
@@ -165,12 +172,18 @@ $spiral             # Bootstrap or audit a project scaffold
 │   ├── slipbox/
 │   │   ├── SKILL.md         # Skill definition (Codex + Claude)
 │   │   └── commands/        # Claude Code slash commands
-│   └── spiral/
-│       ├── SKILL.md         # Skill definition (Codex + Claude)
-│       ├── commands/        # Claude Code slash commands (init, audit)
-│       ├── templates/       # Files written into target repos by /spiral init
-│       ├── scripts/         # init.sh and audit.sh
-│       └── docs/            # methodology and case studies
+│   ├── spiral/
+│   │   ├── SKILL.md         # Skill definition (Codex + Claude)
+│   │   ├── commands/        # Claude Code slash commands (init, audit)
+│   │   ├── templates/       # Files written into target repos by /spiral init
+│   │   ├── scripts/         # init.sh and audit.sh
+│   │   └── docs/            # methodology and case studies
+│   └── spiral-html/
+│       ├── SKILL.md         # Skill definition (YAML frontmatter + HTML body)
+│       ├── commands/        # /spiral-html init, /spiral-html audit
+│       ├── templates/       # HTML scaffold written into target repos
+│       ├── scripts/         # init.sh and audit.sh (HTML-aware)
+│       └── docs/            # methodology.html and case-studies.html
 └── README.md
 ```
 

--- a/plugins/spiral-html/.claude-plugin/plugin.json
+++ b/plugins/spiral-html/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "spiral-html",
+  "description": "HTML-first variant of the Spiral structural-discipline scaffold. Bootstraps and audits a vision-to-delivered scaffold whose ledgers, rules, and contracts are written in HTML rather than Markdown. Same methodology as spiral; different communication medium.",
+  "version": "1.0.0"
+}

--- a/plugins/spiral-html/README.md
+++ b/plugins/spiral-html/README.md
@@ -1,0 +1,50 @@
+<h1>spiral-html</h1>
+
+<p>Bootstrap and audit the structural-discipline scaffold that lets autonomous PR loops run for weeks without losing context, terminating prematurely, or accumulating debt. HTML-first variant of <code>spiral</code>: every ledger, rule, and contract is authored in HTML rather than Markdown.</p>
+
+<h2>What this is</h2>
+
+<p>A skill for Claude Code and Codex agents. It writes (or audits) the canonical scaffold that turns a fresh repo into a substrate suitable for <code>randroid-loop</code> to drive. The structure mirrors <code>spiral</code> exactly; only the document format differs.</p>
+
+<h2>What it solves</h2>
+
+<p>Three sibling skills (<code>randroid-loop</code>, <code>task-tracking-dots</code>, and this one) form the autonomous-loop trio:</p>
+
+<ul>
+  <li><code>task-tracking-dots</code>: work items (the queue).</li>
+  <li><code>randroid-loop</code>: execution (the worker).</li>
+  <li><code>spiral-html</code>: substrate (the contract, vision, ledgers, and gates the worker consumes and updates).</li>
+</ul>
+
+<p>Without a spiral substrate, <code>randroid-loop</code> runs against muscle memory: there is no copy-pasteable contract, no anti-Flatline guardrails (chapter-granular coverage, missing qualitative gate), and no audit pass for an existing repo.</p>
+
+<h2>Why HTML</h2>
+
+<p>HTML is the new way to communicate to agents. Where Markdown leans on heading depth and indentation, HTML carries explicit semantics in <code>data-*</code> attributes and structural elements. An agent reading <code>&lt;section data-q="Q-007" data-status="open"&gt;</code> can locate, cite, and update without prose parsing. The audit script in this skill exploits that: it greps for HTML attributes rather than heading prefixes.</p>
+
+<h2>Quick start</h2>
+
+<p>In a fresh git repo:</p>
+
+<pre><code>/spiral-html init</code></pre>
+
+<p>Or from the shell:</p>
+
+<pre><code>bash ${CLAUDE_PLUGIN_ROOT}/scripts/init.sh "MyProject" "one-line pitch" "Next.js + Three.js"</code></pre>
+
+<p>This writes <code>AGENTS.html</code>, the <code>AGENTS.md</code> + <code>CLAUDE.md</code> shims, and the <code>docs/</code> HTML ledger set. Add your first GDD section under <code>docs/gdd/</code>, then start the loop with <code>/randroid-loop implement</code>.</p>
+
+<p>In an existing repo:</p>
+
+<pre><code>/spiral-html audit</code></pre>
+
+<p>Prints a remediation checklist for any drift from the canonical structure.</p>
+
+<h2>See also</h2>
+
+<ul>
+  <li><code>docs/methodology.html</code>: the meta-pattern essay.</li>
+  <li><code>docs/case-studies.html</code>: VibeRacer, VibeGear2, Flatline distilled.</li>
+  <li><code>SKILL.md</code>: the agent-facing primary doc.</li>
+  <li><code>../spiral/</code>: the Markdown-first sibling skill (same methodology, different medium).</li>
+</ul>

--- a/plugins/spiral-html/SKILL.md
+++ b/plugins/spiral-html/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: spiral-html
+description: HTML-first bootstrap and audit of the structural-discipline scaffold (GDD tree, coverage ledger, progress log, open questions, followups, playtest gate) that takes a vision into a delivered system through small iterations whose state lives in git, not the agent's head. Same methodology as spiral; ledgers, rules, and contracts are written in HTML rather than Markdown. Slash commands /spiral-html-init and /spiral-html-audit live under commands/.
+---
+
+<h1>Spiral (HTML edition)</h1>
+
+<p>The methodology for sustaining a multi-week autonomous PR loop without the agent losing context, running out of work prematurely, or accumulating debt. This is the HTML-first variant of <code>spiral</code>: the scaffold is identical in shape, but every ledger, rule, and contract is authored as HTML rather than Markdown.</p>
+
+<p>The agent does not remember the project. The project remembers itself. Every kind of state lives in git-tracked ledger files with rigid templates. The agent's job collapses to: read ledgers, pick the next slice, run the loop, update ledgers. Every iteration returns to the same artifacts and finds them advanced. The shape is not a loop, it is a spiral: forward-while-circling.</p>
+
+<h2>Why HTML</h2>
+
+<p>HTML is the new way to communicate to agents. Structured elements (<code>&lt;section&gt;</code>, <code>&lt;article&gt;</code>, <code>&lt;table&gt;</code>, <code>&lt;ol&gt;</code>, <code>&lt;dl&gt;</code>, <code>&lt;details&gt;</code>) carry semantics that Markdown discards. An agent reading <code>&lt;section data-role="rule" data-id="rule-1"&gt;</code> can locate, cite, and update content without parsing prose. The audit script in this skill exploits that: it grep-checks for HTML attributes rather than heading prefixes.</p>
+
+<p>Tradeoffs:</p>
+
+<ul>
+  <li>Codex's native <code>AGENTS.md</code> walk does not pick up <code>AGENTS.html</code>. This skill ships its own <code>AGENTS.html</code> and a tiny <code>AGENTS.md</code> shim that points at it.</li>
+  <li>Claude Code's <code>CLAUDE.md</code> import similarly cannot import an <code>.html</code> file directly; the shim handles that too.</li>
+  <li>Path-scoped Rules under <code>.claude/rules/</code> retain YAML frontmatter (Claude Code requires it for path globbing); only the body becomes HTML.</li>
+</ul>
+
+<h2>When to invoke</h2>
+
+<ul>
+  <li><code>/spiral-html init</code>: at the start of a fresh project. Writes the canonical HTML scaffold (rules, plan, agreement, GDD tree, coverage ledger, progress log, open questions, followups, playtest, fun-factor audit) into the current repo.</li>
+  <li><code>/spiral-html audit</code>: on an existing project. Diffs the repo against the canonical HTML structure and prints a remediation checklist. Catches the three known failure modes (monolith GDD, chapter-granular coverage, missing qualitative gate) plus generic drift.</li>
+</ul>
+
+<p>Per-slice execution (read context, branch, implement, PR, merge, repeat) is the job of <code>randroid-loop</code>. Per-task tracking is the job of <code>task-tracking-dots</code>. This skill is the substrate those two run against.</p>
+
+<h2>Why this exists: the three case studies</h2>
+
+<p>Three multi-week autonomous-loop projects produced three outcomes. The pattern is in <code>docs/case-studies.html</code>. The short version:</p>
+
+<ul>
+  <li><strong>VibeRacer (14 days, 184 commits)</strong>: shipped a complete v1. Single-file 28-section GDD with explicit out-of-scope §18 fence. The loop terminated cleanly.</li>
+  <li><strong>VibeGear2 (7 days, 298 commits)</strong>: still actively shipping P0/P1 fun work a week in. Sectioned <code>docs/gdd/</code> tree, 102 atomic coverage rows, plus <code>FUN_FACTOR_GAP_AUDIT</code> and <code>RELEASE_FUN_PLAYTEST</code> as a second qualitative gate that re-opens the loop after systems land.</li>
+  <li><strong>Flatline (3 days, 94 commits)</strong>: self-terminated with 0 open dots, 0 open questions, 1 deferred doc cleanup. The product was not fun. Coverage rows were chapter-granular (11 rows, all <code>implemented</code> once <em>any</em> code shipped). No qualitative gate.</li>
+</ul>
+
+<p>Flatline is the failure case this skill explicitly prevents. The audit script flags both the chapter-granular coverage anti-pattern and the missing qualitative gate.</p>
+
+<h2>The scaffold</h2>
+
+<p><code>/spiral-html init</code> writes these files into the target repo:</p>
+
+<table>
+  <thead>
+    <tr><th>Path</th><th>Role</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>AGENTS.html</code></td><td>Rules-as-contract in HTML: em-dash ban, pre-slice reading list, stack constraints, commit style, autonomous PR loop reference, secrets policy, testing expectations, pre-commit checklist.</td></tr>
+    <tr><td><code>AGENTS.md</code></td><td>One-line shim pointing at <code>AGENTS.html</code> so Codex's root-down walk still finds the contract.</td></tr>
+    <tr><td><code>CLAUDE.md</code></td><td>One-line shim pointing at <code>AGENTS.html</code> so Claude Code picks up the same rules.</td></tr>
+    <tr><td><code>docs/IMPLEMENTATION_PLAN.html</code></td><td>The 18-step loop contract. Slice selection priority. Definition of done.</td></tr>
+    <tr><td><code>docs/WORKING_AGREEMENT.html</code></td><td>Process: branches, commits, PR template, bot-review settled-wait gate, verification minimums, merge-and-deploy expectations, risk gates.</td></tr>
+    <tr><td><code>docs/gdd/index.html</code></td><td>GDD tree index. Each requirement is its own file. Build logs grow per-section as work ships.</td></tr>
+    <tr><td><code>docs/GDD_COVERAGE.json</code></td><td>Atomic-row spec to code traceability. One row per requirement, not per chapter. Stays JSON (data, not prose).</td></tr>
+    <tr><td><code>docs/PROGRESS_LOG.html</code></td><td>Append-only slice receipts as <code>&lt;article data-slice="..."&gt;</code> elements (Branch / Changed / Verification / Assumptions / GDD coverage / Followups). Newest on top.</td></tr>
+    <tr><td><code>docs/OPEN_QUESTIONS.html</code></td><td><code>&lt;section data-q="Q-NNN"&gt;</code> entries with options, recommended default, status, resolution. Defaults let the loop ship without blocking.</td></tr>
+    <tr><td><code>docs/FOLLOWUPS.html</code></td><td><code>&lt;section data-f="F-NNN"&gt;</code> entries with priority (<code>blocks-release</code>, <code>nice-to-have</code>, <code>polish</code>), blocker condition, unblock condition.</td></tr>
+    <tr><td><code>docs/DEPENDENCY_LEDGER.html</code></td><td>Watched dependencies with currently-pinned version + per-dep upgrade procedure. The Dependency Upgrade Gate fires every loop iteration that touches <code>main</code>.</td></tr>
+    <tr><td><code>docs/PLAYTEST.html</code></td><td>Qualitative second-gate checklist. The loop is not done until this resolves.</td></tr>
+    <tr><td><code>docs/FUN_FACTOR_AUDIT.html</code></td><td>Qualitative gap-finder. Run when coverage is ≥80% done. Source of P0/P1 polish work.</td></tr>
+    <tr><td><code>.claude/rules/slice-discipline.md</code></td><td>Path-scoped Rule. YAML frontmatter for path globbing; HTML body. Loads when editing source. Enforces "no drive-by refactors, no speculative abstractions, refactor-in-slice".</td></tr>
+    <tr><td><code>.claude/rules/ledger-append-only.md</code></td><td>Path-scoped Rule. YAML frontmatter for path globbing; HTML body. Loads when editing the four ledger files. Enforces append-only, never-rewrite-past-entries.</td></tr>
+    <tr><td><code>.claude/rules/gdd-build-log.md</code></td><td>Path-scoped Rule. YAML frontmatter for path globbing; HTML body. Loads when editing GDD section files. Enforces build-log-on-every-shipped-feature.</td></tr>
+  </tbody>
+</table>
+
+<h2>Cross-tool compatibility</h2>
+
+<p>The HTML-first scaffold cannot rely on the same discovery contracts as the Markdown version. The shim strategy preserves both tools at the cost of two tiny pointer files:</p>
+
+<ul>
+  <li><code>AGENTS.md</code> (the Codex-required filename) contains one line: <code>See AGENTS.html for the active contract.</code> Codex will still walk into the repo; the agent reading it follows the pointer.</li>
+  <li><code>CLAUDE.md</code> (the Claude Code import filename) contains one line: <code>See AGENTS.html for the active contract.</code> Same pattern.</li>
+  <li><code>.claude/rules/*.md</code> keep YAML frontmatter and the <code>.md</code> filename because Claude Code's path-scoped Rules system parses the frontmatter to decide when to load. The body inside each rule is HTML.</li>
+  <li>The Codex per-directory <code>AGENTS.md</code> symlinks become symlinks to the rules files (still <code>.md</code>); Codex reads the YAML frontmatter and HTML body uniformly.</li>
+</ul>
+
+<h2>The seven parts of the spiral</h2>
+
+<ol>
+  <li><strong>Vision</strong>: the canonical spec (GDD tree, atomic requirements) as HTML section files.</li>
+  <li><strong>Contract</strong>: the three docs that govern every iteration (rules in <code>AGENTS.html</code>, plan, agreement).</li>
+  <li><strong>Slice</strong>: the bounded unit of work (one PR, one log entry, small enough that a botched slice is reverted in one click).</li>
+  <li><strong>Ledgers</strong>: externalized memory (progress log, open questions, followups, coverage) as append-only HTML elements with <code>data-*</code> ids.</li>
+  <li><strong>Gates</strong>: what blocks merge AND what triggers a slice. Mechanical (CI green, type-check, tests, no em-dash, bot-review settled). Qualitative (playtest, fun-factor audit). Dependency Upgrade Gate (see <code>docs/DEPENDENCY_LEDGER.html</code>): a watched-dep release is the same kind of fresh state as a new commit on <code>main</code>; the agent observes and acts at every loop boundary that touches <code>main</code>. The qualitative gate is the second gate that prevents Flatline-style early termination.</li>
+  <li><strong>Selection rule</strong>: what to work on next: red CI &gt; pending dep upgrade &gt; P0/P1 dot &gt; answered open question &gt; high-priority followup &gt; coverage gap &gt; partial GDD section &gt; cleanup.</li>
+  <li><strong>Loop</strong>: the continuous operation. Read context, pick slice, branch, implement, test, update ledgers, PR, handle review, wait for bot + CI, merge, pull main, smoke prod, close item, start next. Never voluntarily idles. Executed by <code>randroid-loop</code>.</li>
+</ol>
+
+<h2>How <code>init</code> works</h2>
+
+<p>Invocation: <code>/spiral-html init</code> from inside a target git repo, or <code>bash ${CLAUDE_PLUGIN_ROOT}/scripts/init.sh "&lt;ProjectName&gt;" "&lt;one-line-pitch&gt;" "&lt;stack&gt;"</code>.</p>
+
+<p>The script:</p>
+
+<ol>
+  <li>Refuses to run if <code>AGENTS.html</code> already exists at the repo root. Use <code>audit</code> instead.</li>
+  <li>Prompts for project name, one-line pitch, and stack if not passed as args.</li>
+  <li>Copies every template file into the target repo, substituting <code>{{PROJECT_NAME}}</code>, <code>{{PITCH}}</code>, <code>{{STACK}}</code>, <code>{{TODAY}}</code>.</li>
+  <li>Creates <code>docs/gdd/</code> for the GDD tree and <code>.claude/rules/</code> for the path-scoped Rules.</li>
+  <li>Writes the <code>AGENTS.md</code> and <code>CLAUDE.md</code> shims that point at <code>AGENTS.html</code>.</li>
+  <li>Verifies em-dash cleanliness on every written file.</li>
+  <li>Prints a next-steps note: draft the first GDD section under <code>docs/gdd/</code>, then run <code>/randroid-loop implement</code> to start the spiral.</li>
+</ol>
+
+<h2>How <code>audit</code> works</h2>
+
+<p>Invocation: <code>/spiral-html audit</code> from inside any git repo, or <code>bash ${CLAUDE_PLUGIN_ROOT}/scripts/audit.sh</code>.</p>
+
+<p>The script runs nine checks and prints a remediation checklist:</p>
+
+<ol>
+  <li><strong>Missing canonical files.</strong> Verifies the full HTML scaffold (<code>AGENTS.html</code> plus the shims, the docs HTML ledger set including <code>DEPENDENCY_LEDGER.html</code>, the three <code>.claude/rules</code> files) is present.</li>
+  <li><strong>Monolith GDD.</strong> Warns if <code>docs/GDD.html</code> exists alone without a <code>docs/gdd/</code> directory.</li>
+  <li><strong>Chapter-granular coverage.</strong> Counts rows in <code>docs/GDD_COVERAGE.json</code>. Warns if row count is implausibly low for project age (heuristic: fewer than 14 rows per project-week).</li>
+  <li><strong>Missing qualitative gate.</strong> Warns if <code>docs/PLAYTEST.html</code> or <code>docs/FUN_FACTOR_AUDIT.html</code> is missing.</li>
+  <li><strong>Stale progress log.</strong> Reads the newest <code>&lt;article data-date="YYYY-MM-DD"&gt;</code> in <code>docs/PROGRESS_LOG.html</code>. Warns if older than 7 days.</li>
+  <li><strong>Open questions without defaults.</strong> Warns on any <code>&lt;section data-q="..."&gt;</code> missing a <code>&lt;dt&gt;Recommended default&lt;/dt&gt;</code> entry.</li>
+  <li><strong>Followups without priority.</strong> Warns on any <code>&lt;section data-f="..."&gt;</code> missing a <code>data-priority</code> attribute.</li>
+  <li><strong>Em-dash drift.</strong> Greps the canonical files for U+2014 / U+2013. Warns on hits.</li>
+  <li><strong>Dependency ledger present.</strong> Warns if <code>docs/DEPENDENCY_LEDGER.html</code> is missing or empty (no <code>&lt;section id="watch-list"&gt;</code> recorded).</li>
+</ol>
+
+<p>The output is a checklist, not a generated remediation file. One canonical place per kind of state.</p>
+
+<h2>Composition</h2>
+
+<ul>
+  <li><code>randroid-loop</code> reads the ledgers this skill writes. The loop's research and implement modes both name <code>OPEN_QUESTIONS</code> and <code>FOLLOWUPS</code> as required reads. With this skill, those references resolve to the <code>.html</code> files.</li>
+  <li><code>task-tracking-dots</code> is the work-item tracker. <code>Q-NNN</code> entries that resolve into work become Dots. <code>F-NNN</code> entries with <code>data-priority="blocks-release"</code> become Dots.</li>
+  <li>This skill is stateless. All state lives in the target repo's ledger files.</li>
+</ul>
+
+<h2>Architecture</h2>
+
+<pre><code>spiral-html/
+├── SKILL.md                    # This file (YAML frontmatter + HTML body)
+├── README.md                   # Human-facing one-pager (HTML body)
+├── .claude-plugin/
+│   └── plugin.json             # Plugin metadata
+├── commands/
+│   ├── spiral-html-init.md     # /spiral-html init slash command
+│   └── spiral-html-audit.md    # /spiral-html audit slash command
+├── templates/
+│   ├── AGENTS.html             # The contract, in HTML
+│   ├── AGENTS-shim.md          # Codex pointer to AGENTS.html
+│   ├── CLAUDE-shim.md          # Claude Code pointer to AGENTS.html
+│   ├── IMPLEMENTATION_PLAN.html
+│   ├── WORKING_AGREEMENT.html
+│   ├── docs-gdd-index.html
+│   ├── GDD_COVERAGE.json
+│   ├── PROGRESS_LOG.html
+│   ├── OPEN_QUESTIONS.html
+│   ├── FOLLOWUPS.html
+│   ├── DEPENDENCY_LEDGER.html
+│   ├── PLAYTEST.html
+│   ├── FUN_FACTOR_AUDIT.html
+│   ├── dot-claude-rules-slice-discipline.md
+│   ├── dot-claude-rules-ledger-append-only.md
+│   └── dot-claude-rules-gdd-build-log.md
+├── scripts/
+│   ├── init.sh                 # Bootstrap into a target repo
+│   └── audit.sh                # Diff target repo against canon
+└── docs/
+    ├── methodology.html        # The meta-pattern essay
+    └── case-studies.html       # VibeRacer / VibeGear2 / Flatline
+</code></pre>

--- a/plugins/spiral-html/SKILL.md
+++ b/plugins/spiral-html/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spiral-html
-description: HTML-first bootstrap and audit of the structural-discipline scaffold (GDD tree, coverage ledger, progress log, open questions, followups, playtest gate) that takes a vision into a delivered system through small iterations whose state lives in git, not the agent's head. Same methodology as spiral; ledgers, rules, and contracts are written in HTML rather than Markdown. Slash commands /spiral-html-init and /spiral-html-audit live under commands/.
+description: "HTML-first bootstrap and audit of the structural-discipline scaffold (GDD tree, coverage ledger, progress log, open questions, followups, playtest gate) that takes a vision into a delivered system through small iterations whose state lives in git, not the agent's head. Same methodology as spiral; ledgers, rules, and contracts are written in HTML rather than Markdown. Slash commands /spiral-html-init and /spiral-html-audit live under commands/."
 ---
 
 <h1>Spiral (HTML edition)</h1>

--- a/plugins/spiral-html/commands/spiral-html-audit.md
+++ b/plugins/spiral-html/commands/spiral-html-audit.md
@@ -1,0 +1,39 @@
+<h1>/spiral-html audit</h1>
+
+<p>Diff the current repo against the canonical HTML-first spiral scaffold and print a remediation checklist.</p>
+
+<h2>When to use</h2>
+
+<p>On any existing repo to check whether it is a fit substrate for an autonomous PR loop. Runs nine checks and reports drift. Does not modify anything.</p>
+
+<p>Run this:</p>
+
+<ul>
+  <li>After <code>randroid-loop</code> completes a long run, to surface stale ledgers.</li>
+  <li>Before assuming a project is "done." Catches the Flatline failure mode (chapter-granular coverage + missing qualitative gate = early termination).</li>
+  <li>When inheriting a project that was set up without <code>spiral-html init</code>, to see how much retrofit is needed.</li>
+</ul>
+
+<h2>How to invoke</h2>
+
+<pre><code>bash ${CLAUDE_PLUGIN_ROOT}/scripts/audit.sh [path-to-repo]</code></pre>
+
+<p>Default path is the current directory.</p>
+
+<h2>What it checks</h2>
+
+<ol>
+  <li>Missing canonical files (including <code>docs/DEPENDENCY_LEDGER.html</code>).</li>
+  <li>Monolith <code>docs/GDD.html</code> instead of a <code>docs/gdd/</code> tree.</li>
+  <li>Chapter-granular coverage rows (heuristic: fewer than 14 rows per project-week).</li>
+  <li>Missing qualitative gate (<code>docs/PLAYTEST.html</code> or <code>docs/FUN_FACTOR_AUDIT.html</code>).</li>
+  <li>Stale progress log (newest <code>&lt;article data-date="..."&gt;</code> older than 7 days).</li>
+  <li>Open questions without a <code>&lt;dt&gt;Recommended default&lt;/dt&gt;</code> entry.</li>
+  <li>Followups without a <code>data-priority</code> attribute.</li>
+  <li>Em-dash drift in the canonical files.</li>
+  <li><code>docs/DEPENDENCY_LEDGER.html</code> missing the <code>&lt;section id="watch-list"&gt;</code> region (the Dependency Upgrade Gate has nothing to fire against without it).</li>
+</ol>
+
+<h2>Output</h2>
+
+<p>A checklist with one line per finding, ordered from most-blocking to least-blocking. No remediation file is written. Fix in place, re-run.</p>

--- a/plugins/spiral-html/commands/spiral-html-init.md
+++ b/plugins/spiral-html/commands/spiral-html-init.md
@@ -1,0 +1,35 @@
+<h1>/spiral-html init</h1>
+
+<p>Bootstrap the HTML-first structural-discipline scaffold into the current repo.</p>
+
+<h2>When to use</h2>
+
+<p>At the start of a fresh project, before any feature code. Writes the canonical files (<code>AGENTS.html</code>, the <code>AGENTS.md</code> + <code>CLAUDE.md</code> shims, plus the <code>docs/</code> HTML ledger set, including <code>docs/DEPENDENCY_LEDGER.html</code> and the qualitative-gate docs) so an autonomous PR loop can run against the repo.</p>
+
+<p>Refuses to run if <code>AGENTS.html</code> already exists. Use <code>/spiral-html audit</code> on existing repos instead.</p>
+
+<h2>How to invoke</h2>
+
+<p>Ask the user three questions via <code>AskUserQuestion</code> before running:</p>
+
+<ol>
+  <li><strong>Project name.</strong> Used in headers and substituted as <code>{{PROJECT_NAME}}</code>.</li>
+  <li><strong>One-line pitch.</strong> Substituted as <code>{{PITCH}}</code>. Used in <code>AGENTS.html</code> and the GDD index.</li>
+  <li><strong>Stack.</strong> Substituted as <code>{{STACK}}</code>. Used in <code>AGENTS.html</code> Rule 3. Free text. Examples: "Next.js + Three.js + Vercel KV", "Godot 4.x + GDScript", "Rust + axum + Postgres".</li>
+</ol>
+
+<p>Then run:</p>
+
+<pre><code>bash ${CLAUDE_PLUGIN_ROOT}/scripts/init.sh "&lt;name&gt;" "&lt;pitch&gt;" "&lt;stack&gt;"</code></pre>
+
+<p>After the script completes:</p>
+
+<ol>
+  <li>Print the list of written files.</li>
+  <li>Tell the user the next step is to draft the first GDD section under <code>docs/gdd/&lt;n&gt;-&lt;title&gt;.html</code>.</li>
+  <li>Suggest <code>/randroid-loop implement</code> once the first GDD section exists.</li>
+</ol>
+
+<h2>Output</h2>
+
+<p>The script prints every written file path, plus a one-line note for the user about next steps.</p>

--- a/plugins/spiral-html/docs/case-studies.html
+++ b/plugins/spiral-html/docs/case-studies.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Case studies: VibeRacer, VibeGear2, Flatline</title>
+</head>
+<body>
+
+<h1>Case studies: VibeRacer, VibeGear2, Flatline</h1>
+
+<p>Three multi-week autonomous-loop projects. Three outcomes. The pattern is what <code>spiral-html</code> codifies.</p>
+
+<section id="comparison">
+  <h2>Comparison</h2>
+  <table>
+    <thead>
+      <tr>
+        <th></th>
+        <th>Flatline</th>
+        <th>VibeRacer</th>
+        <th>VibeGear2</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr><td>Duration</td><td>3 days</td><td>14 days</td><td>7 days</td></tr>
+      <tr><td>Commits</td><td>94</td><td>184</td><td>298</td></tr>
+      <tr><td>GDD shape</td><td>One 29K monolith</td><td>Single file</td><td>Sectioned tree under <code>docs/gdd/</code></td></tr>
+      <tr><td><code>GDD_COVERAGE</code> rows</td><td>11 (chapter-granular)</td><td>12 sections</td><td>102 atomic requirements</td></tr>
+      <tr><td>Qualitative gate</td><td>None</td><td>None visible</td><td><code>FUN_FACTOR_GAP_AUDIT</code> + <code>RELEASE_FUN_PLAYTEST</code> checklist</td></tr>
+      <tr><td>Outcome</td><td>Self-terminated early</td><td>Shipped clean v1</td><td>Still actively shipping P0 / P1 fun work</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section id="viberacer">
+  <h2>VibeRacer (the success)</h2>
+  <p>14 days, 184 commits, single-file 28-section GDD with explicit out-of-scope §18 fence, build logs that grow per section as work ships. Operates a continuous PR loop with bot-review settled-wait gate, em-dash ban as a canary, simple-consistent-flow rule preventing branchy UX decisions, refactor-in-slice rule preventing cleanup piles.</p>
+  <p>Closed cleanly because:</p>
+  <ul>
+    <li>The GDD §18 fence prevented scope creep.</li>
+    <li>Atomic-feature slices (one PR each) made the verification cost-per-slice low.</li>
+    <li>Build logs in each GDD section paid the doc-update tax up front so the next slice could start cheap.</li>
+    <li>The <code>PROGRESS_LOG</code> / <code>OPEN_QUESTIONS</code> / <code>FOLLOWUPS</code> ledgers kept the agent unstuck without dev sign-off.</li>
+  </ul>
+  <p>What VibeRacer did NOT have: an explicit qualitative gate. It still terminated cleanly because v1 was scoped tightly and §18: Out of scope listed everything that would have triggered scope creep. The single-file monolithic GDD was the size of v1, not the limit of the methodology.</p>
+  <p>The lesson: a tightly-scoped product with a strong out-of-scope fence can survive without a qualitative gate. A more ambitious product cannot.</p>
+</section>
+
+<section id="vibegear2">
+  <h2>VibeGear2 (the active success)</h2>
+  <p>7 days, 298 commits, sectioned <code>docs/gdd/</code> tree, 102 atomic coverage rows, plus <code>FUN_FACTOR_GAP_AUDIT</code> (May 1) and <code>RELEASE_FUN_PLAYTEST</code> (May 2). The audit and playtest doc were added explicitly <em>after</em> the systems-level coverage was mostly done, in response to the realization that the loop was about to terminate prematurely if it kept using only the coverage ledger as its definition of done.</p>
+  <p>Still actively chasing P0 / P1 fun gaps a week in, despite having 3× the commits of VibeRacer at the same calendar moment. That is not a failure mode; it is the loop staying alive on the right work.</p>
+  <p>The two key VibeGear2 additions:</p>
+  <ol>
+    <li><strong><code>docs/gdd/</code> tree, not a monolith.</strong> Coverage rows can be authored at requirement granularity (102 rows for a 7-day project, ~14 rows per project-day) instead of chapter granularity (Flatline's 11 rows for a 3-day project, ~4 rows per project-day).</li>
+    <li><strong>Qualitative gate.</strong> <code>FUN_FACTOR_GAP_AUDIT</code> is the <em>backlog generator</em> and <code>RELEASE_FUN_PLAYTEST</code> is the <em>check</em> that the gate is closed. Together they keep the loop alive past the moment when systems exist.</li>
+  </ol>
+</section>
+
+<section id="flatline">
+  <h2>Flatline (the failure case)</h2>
+  <p>3 days, 94 commits, single-file GDD, 11 chapter-granular coverage rows, no qualitative gate. By 2026-05-02 the project had 0 open dots, 0 open questions, and 1 deferred low-priority doc cleanup. A complete-on-paper game. Not a fun game.</p>
+  <p>Root cause: the ledger tracked <em>systems</em> at chapter granularity ("billboard enemies exist," "hazards exist"), so the moment each system had any implementation plus a smoke test, the row flipped to <code>implemented</code> and the loop self-terminated. There were no rows for "the first 90 seconds sells the loop," "AI archetypes feel different," or "the game is fun." There was no playtest doc that would surface those gaps.</p>
+  <p>VibeGear2 hit the same wall a week earlier and explicitly responded by writing the audit and playtest docs. Flatline did not, and the loop ran out of work before the product was good.</p>
+</section>
+
+<section id="the-fix">
+  <h2>The fix encoded in <code>spiral-html</code></h2>
+  <p><code>spiral-html init</code> ships <code>PLAYTEST.html</code> and <code>FUN_FACTOR_AUDIT.html</code> by default. The Implementation Plan template's Project Closure rule names all three closure conditions: every coverage row is <code>done</code>, every playtest checklist item is checked or deferred, and the latest fun-factor audit produced no new P0 / P1 gaps.</p>
+  <p><code>spiral-html audit</code> flags the Flatline anti-patterns directly: monolith GDD, chapter-granular coverage (heuristic: fewer than 14 rows per project-week), missing playtest, missing fun-factor audit. Running it on Flatline produces explicit warnings for both the chapter-granular coverage and the missing qualitative gate. Running it on VibeRacer produces zero structural warnings but flags the missing qualitative-gate docs as "you got away with it because §18 fenced scope, but a more ambitious project would have stalled."</p>
+</section>
+
+<section id="implications">
+  <h2>What this implies for new projects</h2>
+  <p>Use <code>spiral-html init</code> at the start. Author the GDD as a tree from day one. Author coverage rows at requirement granularity from day one. Keep the qualitative gate docs in place even on small projects, because the cost is low and the protection is high.</p>
+  <p>If you inherit an existing project, run <code>spiral-html audit</code>. If it flags chapter-granular coverage or a missing qualitative gate, treat that as a P0 followup. Those are the failures that look like success right up to the moment the loop terminates with a not-fun product.</p>
+</section>
+
+</body>
+</html>

--- a/plugins/spiral-html/docs/methodology.html
+++ b/plugins/spiral-html/docs/methodology.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Methodology: how the spiral works</title>
+</head>
+<body>
+
+<h1>Methodology: how the spiral works</h1>
+
+<p>The agent does not remember the project. The project remembers itself. Every kind of state lives in git-tracked files with rigid templates. The agent's job collapses to: read ledgers, pick the next slice, run the loop, update ledgers.</p>
+
+<p>This is the why behind every file the <code>spiral-html</code> skill writes. The methodology is identical to <code>spiral</code>; the format of the files is HTML rather than Markdown.</p>
+
+<section id="the-shape">
+  <h2>The shape</h2>
+  <p>A loop returns to the same point. A spiral returns to the same artifacts but advanced. Every iteration grows the build logs, evidence rows, progress receipts, and resolved questions, so every revisit finds the substrate richer than the last. Drawn as a diagram, it is not a circle. It is a spiral: forward-while-circling.</p>
+  <p>Most agents fail at multi-week projects because they hold context in their head. This methodology externalizes every kind of state into git-tracked files with rigid templates. That removes the rediscovery tax that kills long-running loops.</p>
+</section>
+
+<section id="the-seven-parts">
+  <h2>The seven parts</h2>
+  <p>There are seven, and they map to the canonical scaffold files (eleven full templates plus three rules and the Codex / Claude shims):</p>
+
+  <section data-part="1">
+    <h3>1. Vision</h3>
+    <p><code>docs/gdd/</code> is the canonical spec. Each requirement is its own HTML file. Each file carries a <code>&lt;p data-status="..."&gt;</code> element and gains a <code>&lt;section data-role="build-log"&gt;</code> subsection as work ships. Build logs grow with the code so the next slice can read what landed without rediscovering it.</p>
+    <p><strong>Anti-pattern: monolith GDD.</strong> A single <code>docs/GDD.html</code> file pushes coverage rows toward chapter granularity, which is the Flatline failure mode (rows that flip to <code>done</code> once any code lands).</p>
+  </section>
+
+  <section data-part="2">
+    <h3>2. Contract</h3>
+    <p>Three always-on docs that compound, plus three path-scoped Rules:</p>
+    <ul>
+      <li><code>AGENTS.html</code> codifies rules: em-dash ban, the pre-slice reading list (the file canon), stack constraints, commit-message style, the autonomous PR loop reference, secrets policy, testing expectations, motion / overlay QA, the pre-commit checklist. <code>AGENTS.md</code> is a one-line shim pointing here so Codex's root-down walk still lands.</li>
+      <li><code>CLAUDE.md</code> is a one-line shim pointing at <code>AGENTS.html</code>. Lets Claude Code read the same contract Codex reads, so a single repo works in both tools.</li>
+      <li><code>docs/IMPLEMENTATION_PLAN.html</code> codifies the 18-step loop: read context, branch, implement, test, update ledgers, PR, handle review, wait for bot + CI, merge, pull main, smoke prod, close item, start next.</li>
+      <li><code>docs/WORKING_AGREEMENT.html</code> codifies process: branch naming, commit hygiene, PR contents, the bot-review settled-wait gate (60s + green CI), verification minimums (different for docs vs code), merge-and-deploy expectations, risk gates.</li>
+    </ul>
+    <p>Plus three Claude Code Rules in <code>.claude/rules/</code> that load only when matching files are edited:</p>
+    <ul>
+      <li><code>slice-discipline.md</code> loads when editing source code (<code>src/**</code>, <code>app/**</code>, <code>lib/**</code>, <code>components/**</code>, <code>pages/**</code>, <code>scripts/**</code>, <code>tests/**</code>). Enforces no drive-by refactors, no speculative abstractions, refactor-in-slice.</li>
+      <li><code>ledger-append-only.md</code> loads when editing the four ledger files. Enforces append-only and never-rewrite-past-entries.</li>
+      <li><code>gdd-build-log.md</code> loads when editing GDD section files. Enforces a build-log entry on every shipped feature.</li>
+    </ul>
+    <p>The split between always-on docs (AGENTS.html, the plan, the agreement) and path-scoped Rules is deliberate. Always-on guidance is universal: every slice needs to know about the em-dash ban and the autonomous loop. Path-scoped guidance is specific: only slices that touch ledgers need the append-only rule, only slices that touch the GDD need the build-log rule. Loading them on demand saves context for the work the slice is actually doing.</p>
+    <p>Together they leave no slice-time decision to ad-hoc judgment. The agent does not negotiate the rules, it follows them.</p>
+  </section>
+
+  <section data-part="3">
+    <h3>3. Slice</h3>
+    <p>The unit of work. One PR. One commit-message-sized change. One log entry. Bounded so the agent can finish before context drift, and small enough that a botched slice is reverted in one click.</p>
+    <p>The slice contract is also what enables compounding. Each slice shipping a feature also updates the build log + coverage row + progress entry. The next slice reads those updates and starts cheaper.</p>
+  </section>
+
+  <section data-part="4">
+    <h3>4. Ledgers</h3>
+    <p>Externalized memory. Four append-only files:</p>
+    <ul>
+      <li><code>docs/PROGRESS_LOG.html</code>: receipts as <code>&lt;article data-slice="..." data-date="..."&gt;</code> elements, newest-on-top, never deleted. Each entry's <code>&lt;dl&gt;</code> fields: Branch / Changed / Verification / Assumptions / GDD coverage / Followups.</li>
+      <li><code>docs/OPEN_QUESTIONS.html</code>: <code>&lt;section data-q="Q-NNN" data-status="open|resolved"&gt;</code> entries with Options, <strong>Recommended default</strong> (mandatory), Status, Resolution. The default lets the loop ship without blocking on dev sign-off.</li>
+      <li><code>docs/FOLLOWUPS.html</code>: <code>&lt;section data-f="F-NNN" data-priority="..."&gt;</code> entries with priority (<code>blocks-release</code> | <code>nice-to-have</code> | <code>polish</code>), Blocker condition, Unblock condition.</li>
+      <li><code>docs/GDD_COVERAGE.json</code>: atomic-row spec to code traceability. One row per requirement. Each row carries <code>gddRef</code>, <code>status</code>, <code>implementationRefs</code>, <code>testRefs</code>, <code>followupRefs</code>.</li>
+    </ul>
+    <p>Append-only is the load-bearing convention. A future slice cannot trust ledgers that get retroactively edited.</p>
+  </section>
+
+  <section data-part="5">
+    <h3>5. Gates</h3>
+    <p>What blocks merge. Two kinds:</p>
+    <p><strong>Mechanical:</strong> CI green, type-check, tests, no em-dash, bot-review settled-wait. These are checked by tools.</p>
+    <p><strong>Qualitative:</strong> <code>docs/PLAYTEST.html</code> (release checklist) and <code>docs/FUN_FACTOR_AUDIT.html</code> (gap audit). These are the second gate that re-opens the loop after systems land. Coverage rows say a <em>system</em> exists. The qualitative gate asks whether the system <em>delivers experience</em>.</p>
+    <p>Without the qualitative gate, the loop terminates the moment every coverage row is <code>done</code>, even if the product is not actually good. This is the Flatline failure mode and the reason <code>PLAYTEST.html</code> and <code>FUN_FACTOR_AUDIT.html</code> ship by default.</p>
+  </section>
+
+  <section data-part="6">
+    <h3>6. Selection rule</h3>
+    <p>What to work on next. Priority order:</p>
+    <ol>
+      <li>Broken <code>main</code>, red CI, broken deploy.</li>
+      <li>P0 / P1 backlog items.</li>
+      <li>Open questions with enough info to resolve under their recommended default.</li>
+      <li>High-priority followups.</li>
+      <li>Coverage gaps marked <code>not_started</code> or <code>partial</code>.</li>
+      <li>GDD requirements with user-visible scope still partial.</li>
+      <li><strong>Qualitative gate items</strong> once coverage is ≥80% done.</li>
+      <li>Cleanup that removes blockers.</li>
+    </ol>
+    <p>Plus the constraint: prefer the smallest slice that creates a useful PR. Avoid mixing unrelated work.</p>
+  </section>
+
+  <section data-part="7">
+    <h3>7. Loop</h3>
+    <p>The continuous operation. Read context, pick slice, branch, implement, test, update ledgers, PR, handle review, wait for bot + CI, merge, pull main, smoke prod, close item, start next.</p>
+    <p>Never voluntarily idles. Executed by <code>randroid-loop</code>.</p>
+  </section>
+</section>
+
+<section id="compounding-effect">
+  <h2>The compounding effect</h2>
+  <p>Each slice that ships also pays the doc-update tax that makes the next slice cheaper. When the next slice starts, it reads the build logs, coverage refs, progress receipts, and resolved questions: all of which are richer than they were one slice ago. That is what makes hundreds of slices in a few weeks tractable.</p>
+  <p>The fastest part of the loop is the part that has been done many times. Each pass through the spiral makes the next pass faster.</p>
+</section>
+
+<section id="convention-beats-configuration">
+  <h2>Why convention beats configuration</h2>
+  <p><code>AGENTS.html</code> Rule 3 nails down the stack: framework, 3D, physics, audio, storage, validation, tests. There is no per-slice "should we add a library?" debate, which is the single biggest time sink in most projects.</p>
+  <p>The em-dash ban is the canary for the same principle: a rule trivial in isolation is useful as a tripwire. An agent that ships an em-dash (U+2014) is an agent that did not run its own pre-commit checklist. The rule doubles as a discipline test.</p>
+</section>
+
+<section id="closure-rule">
+  <h2>The closure rule</h2>
+  <p>The loop ends when all three conditions hold:</p>
+  <ol>
+    <li>Every coverage row is <code>done</code> with implementation and test refs.</li>
+    <li>Every <code>PLAYTEST.html</code> checklist item is checked or explicitly deferred.</li>
+    <li><code>FUN_FACTOR_AUDIT.html</code> has been re-run after the last system landed and produced no new P0 / P1 gaps.</li>
+  </ol>
+  <p>Closing the loop without all three is the Flatline failure mode: a complete-on-paper system that is not actually good. The <code>spiral-html audit</code> script catches a missing qualitative gate so this failure mode is impossible by construction.</p>
+</section>
+
+<section id="why-one-agent">
+  <h2>Why one agent can sustain this</h2>
+  <p>Externalize every kind of state. Externalize every kind of decision. Bound the unit of work. Make doc updates a checked merge gate. Define closure mechanically. Then the agent's job is not "build the project," it is "do the next slice and update the ledgers." That collapse is what makes weeks-long autonomous loops work.</p>
+  <p>Small agent, big paper trail. The agent rotates the spiral; the spiral advances.</p>
+</section>
+
+</body>
+</html>

--- a/plugins/spiral-html/scripts/audit.sh
+++ b/plugins/spiral-html/scripts/audit.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+#
+# spiral-html audit: diff a target repo against the canonical HTML-first
+# spiral scaffold.
+#
+# Usage:
+#   bash audit.sh [path-to-repo]
+#
+# Prints a remediation checklist. Does not modify anything.
+
+set -uo pipefail
+
+TARGET_DIR="${1:-$(pwd)}"
+
+if [[ ! -d "${TARGET_DIR}" ]]; then
+  echo "Error: ${TARGET_DIR} is not a directory." >&2
+  exit 1
+fi
+
+cd "${TARGET_DIR}"
+
+findings=()
+add_finding() {
+  findings+=("$1")
+}
+
+# Check 1: missing canonical files
+canonical=(
+  "AGENTS.html"
+  "AGENTS.md"
+  "CLAUDE.md"
+  "docs/IMPLEMENTATION_PLAN.html"
+  "docs/WORKING_AGREEMENT.html"
+  "docs/gdd/index.html"
+  "docs/GDD_COVERAGE.json"
+  "docs/PROGRESS_LOG.html"
+  "docs/OPEN_QUESTIONS.html"
+  "docs/FOLLOWUPS.html"
+  "docs/DEPENDENCY_LEDGER.html"
+  "docs/PLAYTEST.html"
+  "docs/FUN_FACTOR_AUDIT.html"
+  ".claude/rules/slice-discipline.md"
+  ".claude/rules/ledger-append-only.md"
+  ".claude/rules/gdd-build-log.md"
+)
+
+# Codex symlinks: per-directory AGENTS.md aliases for the rules.
+codex_symlinks=(
+  "docs/AGENTS.md:.claude/rules/ledger-append-only.md"
+  "docs/gdd/AGENTS.md:.claude/rules/gdd-build-log.md"
+)
+
+for f in "${canonical[@]}"; do
+  if [[ ! -e "${f}" ]]; then
+    add_finding "[MISSING] ${f} does not exist. Run /spiral-html init or copy the template manually."
+  fi
+done
+
+# Verify Codex symlinks point to the right targets.
+for entry in "${codex_symlinks[@]}"; do
+  link="${entry%%:*}"
+  target="${entry##*:}"
+  if [[ -L "${link}" ]]; then
+    actual=$(readlink "${link}")
+    expected_suffix="${target}"
+    case "${actual}" in
+      *"${expected_suffix##*/}") : ;;
+      *) add_finding "[CODEX] ${link} is a symlink but points to '${actual}', expected to resolve to ${target}. Codex's AGENTS.md walk may load the wrong content." ;;
+    esac
+  elif [[ -f "${link}" ]]; then
+    add_finding "[CODEX] ${link} exists as a regular file, not a symlink to ${target}. Codex will read this file but it will drift from ${target}. Replace with: ln -sf <relative-path>/${target} ${link}"
+  else
+    add_finding "[CODEX] ${link} is missing. Without it, Codex cannot pick up ${target} on its root-down AGENTS.md walk when working in $(dirname "${link}")/."
+  fi
+done
+
+# Verify the root AGENTS.md / CLAUDE.md shims point at AGENTS.html.
+for shim in "AGENTS.md" "CLAUDE.md"; do
+  if [[ -f "${shim}" ]] && ! grep -q "AGENTS.html" "${shim}" 2>/dev/null; then
+    add_finding "[SHIM] ${shim} exists but does not reference AGENTS.html. In the HTML-first scaffold this file should be a one-paragraph pointer to AGENTS.html so Codex / Claude Code land on the right contract."
+  fi
+done
+
+# Check 2: monolith GDD
+if [[ -f "docs/GDD.html" && ! -d "docs/gdd" ]]; then
+  add_finding "[ANTI-PATTERN] docs/GDD.html exists as a single file. Split into docs/gdd/<n>-<title>.html per requirement. A monolith GDD makes coverage rows chapter-granular by default, which is the Flatline failure mode."
+fi
+
+# Check 3: chapter-granular coverage
+if [[ -f "docs/GDD_COVERAGE.json" ]]; then
+  rows=$(python3 -c "
+import json, sys
+try:
+    with open('docs/GDD_COVERAGE.json') as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        for key in ('rows', 'sections', 'requirements', 'items', 'coverage'):
+            if key in data and isinstance(data[key], list):
+                print(len(data[key]))
+                sys.exit(0)
+        print(0)
+    elif isinstance(data, list):
+        print(len(data))
+    else:
+        print(0)
+except Exception:
+    print(-1)
+" 2>/dev/null)
+
+  if [[ "${rows}" == "-1" ]]; then
+    add_finding "[WARN] docs/GDD_COVERAGE.json could not be parsed as JSON. Fix the file."
+  elif [[ "${rows}" -lt 1 ]]; then
+    add_finding "[WARN] docs/GDD_COVERAGE.json has 0 rows. Add atomic-granularity requirement rows."
+  else
+    age_days=$(git log --reverse --pretty=format:%ct 2>/dev/null | head -1 | awk -v now="$(date +%s)" '{ if ($0 != "") print int((now - $0) / 86400) }')
+    if [[ -n "${age_days}" && "${age_days}" -gt 0 ]]; then
+      project_weeks=$(( (age_days + 6) / 7 ))
+      [[ "${project_weeks}" -lt 1 ]] && project_weeks=1
+      threshold=$(( project_weeks * 14 ))
+      if [[ "${rows}" -lt "${threshold}" ]]; then
+        add_finding "[ANTI-PATTERN] docs/GDD_COVERAGE.json has ${rows} rows for a ~${age_days}-day-old project (~${project_weeks} weeks). Heuristic threshold is ${threshold} (14 rows / project-week). This is likely chapter-granular coverage. The Flatline failure mode is rows that flip to 'done' once any code lands. Split into requirement-granular rows."
+      fi
+    fi
+  fi
+fi
+
+# Check 4: missing qualitative gate
+if [[ ! -f "docs/PLAYTEST.html" ]]; then
+  add_finding "[ANTI-FLATLINE] docs/PLAYTEST.html is missing. Without the second qualitative gate, the loop terminates when systems exist instead of when the product is good."
+fi
+if [[ ! -f "docs/FUN_FACTOR_AUDIT.html" ]]; then
+  add_finding "[ANTI-FLATLINE] docs/FUN_FACTOR_AUDIT.html is missing. Without a periodic gap audit, the backlog will not surface the experience-level work that coverage rows cannot catch."
+fi
+
+# Check 5: stale progress log. Newest article carries data-date="YYYY-MM-DD".
+if [[ -f "docs/PROGRESS_LOG.html" ]]; then
+  newest=$(grep -oE 'data-date="[0-9]{4}-[0-9]{2}-[0-9]{2}"' docs/PROGRESS_LOG.html \
+    | sed -E 's/data-date="([0-9-]+)"/\1/' \
+    | sort -r | head -1)
+  if [[ -n "${newest}" ]]; then
+    newest_ts=$(date -j -f "%Y-%m-%d" "${newest}" +%s 2>/dev/null || date -d "${newest}" +%s 2>/dev/null || echo 0)
+    if [[ "${newest_ts}" -gt 0 ]]; then
+      now_ts=$(date +%s)
+      age_days=$(( (now_ts - newest_ts) / 86400 ))
+      if [[ "${age_days}" -gt 7 ]]; then
+        add_finding "[STALE] docs/PROGRESS_LOG.html newest entry is ${newest} (${age_days} days ago). Loop may be stalled."
+      fi
+    fi
+  else
+    add_finding "[WARN] docs/PROGRESS_LOG.html has no dated entries (looking for <article data-date=\"YYYY-MM-DD\">). Add a slice receipt."
+  fi
+fi
+
+# Check 6: open questions without recommended default.
+# Each open question is a <section data-q="..."> containing a <dt>Recommended default</dt> entry.
+if [[ -f "docs/OPEN_QUESTIONS.html" ]]; then
+  # Skip the template example (which lives inside a <pre><code> block).
+  # Extract one logical question block per data-q occurrence and inspect each.
+  bad_qs=$(python3 - <<'PY'
+import re, sys
+try:
+    src = open('docs/OPEN_QUESTIONS.html', encoding='utf-8').read()
+except Exception:
+    sys.exit(0)
+
+# Strip <pre>...</pre> blocks so the template example does not register.
+src_stripped = re.sub(r'<pre.*?</pre>', '', src, flags=re.DOTALL | re.IGNORECASE)
+
+# Find every <section data-q="...">...</section> in the stripped source.
+pattern = re.compile(r'<section[^>]*data-q="([^"]+)"[^>]*>(.*?)</section>', re.DOTALL | re.IGNORECASE)
+missing = []
+for m in pattern.finditer(src_stripped):
+    qid = m.group(1)
+    body = m.group(2)
+    if not re.search(r'<dt>\s*Recommended default\s*</dt>', body, re.IGNORECASE):
+        missing.append(qid)
+
+for qid in missing:
+    print(qid)
+PY
+)
+  if [[ -n "${bad_qs}" ]]; then
+    add_finding "[WARN] docs/OPEN_QUESTIONS.html has entries without a <dt>Recommended default</dt>. The loop will block on these. Add defaults so the loop ships under them:"
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] && add_finding "    Q-id: ${line}"
+    done <<< "${bad_qs}"
+  fi
+fi
+
+# Check 7: followups without data-priority attribute.
+if [[ -f "docs/FOLLOWUPS.html" ]]; then
+  bad_fs=$(python3 - <<'PY'
+import re, sys
+try:
+    src = open('docs/FOLLOWUPS.html', encoding='utf-8').read()
+except Exception:
+    sys.exit(0)
+
+src_stripped = re.sub(r'<pre.*?</pre>', '', src, flags=re.DOTALL | re.IGNORECASE)
+pattern = re.compile(r'<section[^>]*data-f="([^"]+)"[^>]*>', re.IGNORECASE)
+missing = []
+for m in pattern.finditer(src_stripped):
+    tag = m.group(0)
+    fid = m.group(1)
+    if 'data-priority=' not in tag.lower():
+        missing.append(fid)
+
+for fid in missing:
+    print(fid)
+PY
+)
+  if [[ -n "${bad_fs}" ]]; then
+    add_finding "[WARN] docs/FOLLOWUPS.html has entries without a data-priority attribute. Tag each with data-priority=\"blocks-release\" | \"nice-to-have\" | \"polish\":"
+    while IFS= read -r line; do
+      [[ -n "${line}" ]] && add_finding "    F-id: ${line}"
+    done <<< "${bad_fs}"
+  fi
+fi
+
+# Check 8: em-dash drift in canonical files (U+2014 em-dash, U+2013 en-dash).
+emdash_hits=$(grep -lP '[\x{2014}\x{2013}]' \
+  AGENTS.html \
+  AGENTS.md \
+  CLAUDE.md \
+  docs/IMPLEMENTATION_PLAN.html \
+  docs/WORKING_AGREEMENT.html \
+  docs/PROGRESS_LOG.html \
+  docs/OPEN_QUESTIONS.html \
+  docs/FOLLOWUPS.html \
+  docs/DEPENDENCY_LEDGER.html \
+  docs/PLAYTEST.html \
+  docs/FUN_FACTOR_AUDIT.html \
+  docs/GDD_COVERAGE.json \
+  docs/gdd/index.html \
+  .claude/rules/slice-discipline.md \
+  .claude/rules/ledger-append-only.md \
+  .claude/rules/gdd-build-log.md \
+  2>/dev/null || true)
+if [[ -n "${emdash_hits}" ]]; then
+  add_finding "[STYLE] Em-dash or en-dash found in canonical files. Replace with periods, commas, colons, or parens:"
+  while IFS= read -r line; do
+    [[ -n "${line}" ]] && add_finding "    ${line}"
+  done <<< "${emdash_hits}"
+fi
+
+# Check 9: dependency ledger present and has a watch-list region.
+if [[ -f "docs/DEPENDENCY_LEDGER.html" ]]; then
+  if ! grep -qE '<section[^>]+id="watch-list"' docs/DEPENDENCY_LEDGER.html 2>/dev/null; then
+    add_finding "[DEPS] docs/DEPENDENCY_LEDGER.html exists but has no <section id=\"watch-list\"> region. The Dependency Upgrade Gate cannot find watched deps. Re-copy the template or add the section."
+  fi
+fi
+
+# Output
+echo "spiral-html audit on ${TARGET_DIR}"
+echo
+
+if [[ "${#findings[@]}" -eq 0 ]]; then
+  echo "Clean. No findings."
+  exit 0
+fi
+
+echo "Findings:"
+echo
+for f in "${findings[@]}"; do
+  echo "- ${f}"
+done
+
+echo
+echo "Re-run after remediation."
+exit 1

--- a/plugins/spiral-html/scripts/audit.sh
+++ b/plugins/spiral-html/scripts/audit.sh
@@ -17,7 +17,10 @@ if [[ ! -d "${TARGET_DIR}" ]]; then
   exit 1
 fi
 
-cd "${TARGET_DIR}"
+cd "${TARGET_DIR}" || {
+  echo "Error: cannot enter ${TARGET_DIR}." >&2
+  exit 1
+}
 
 findings=()
 add_finding() {
@@ -218,7 +221,7 @@ PY
 fi
 
 # Check 8: em-dash drift in canonical files (U+2014 em-dash, U+2013 en-dash).
-emdash_hits=$(grep -lP '[\x{2014}\x{2013}]' \
+emdash_hits=$(grep -lE '—|–' \
   AGENTS.html \
   AGENTS.md \
   CLAUDE.md \

--- a/plugins/spiral-html/scripts/init.sh
+++ b/plugins/spiral-html/scripts/init.sh
@@ -101,7 +101,7 @@ ln -sf "../../.claude/rules/gdd-build-log.md" "${TARGET_DIR}/docs/gdd/AGENTS.md"
 written+=("docs/gdd/AGENTS.md (symlink to .claude/rules/gdd-build-log.md)")
 
 # Em-dash sanity check on the written files (U+2014 em-dash, U+2013 en-dash).
-if grep -lP '[\x{2014}\x{2013}]' \
+if grep -lE '—|–' \
   "${TARGET_DIR}/AGENTS.html" \
   "${TARGET_DIR}/AGENTS.md" \
   "${TARGET_DIR}/CLAUDE.md" \

--- a/plugins/spiral-html/scripts/init.sh
+++ b/plugins/spiral-html/scripts/init.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# spiral-html init: bootstrap the HTML-first structural-discipline scaffold
+# into the current repo.
+#
+# Usage:
+#   bash init.sh "<project-name>" "<one-line-pitch>" "<stack>"
+#
+# Refuses to run if AGENTS.html already exists. Use audit.sh on existing repos.
+
+set -euo pipefail
+
+PROJECT_NAME="${1:-}"
+PITCH="${2:-}"
+STACK="${3:-}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATES_DIR="${SCRIPT_DIR}/../templates"
+TARGET_DIR="$(pwd)"
+TODAY="$(date +%Y-%m-%d)"
+
+if [[ -z "${PROJECT_NAME}" ]]; then
+  read -r -p "Project name: " PROJECT_NAME
+fi
+if [[ -z "${PITCH}" ]]; then
+  read -r -p "One-line pitch: " PITCH
+fi
+if [[ -z "${STACK}" ]]; then
+  read -r -p "Stack (e.g. 'Next.js + Three.js + Vercel KV'): " STACK
+fi
+
+if [[ -z "${PROJECT_NAME}" || -z "${PITCH}" || -z "${STACK}" ]]; then
+  echo "Error: project name, pitch, and stack are all required." >&2
+  exit 1
+fi
+
+if [[ -e "${TARGET_DIR}/AGENTS.html" ]]; then
+  echo "Error: AGENTS.html already exists at ${TARGET_DIR}." >&2
+  echo "       Use audit.sh on existing repos." >&2
+  exit 1
+fi
+
+mkdir -p "${TARGET_DIR}/docs/gdd" "${TARGET_DIR}/.claude/rules"
+
+# Bash parameter expansion does literal string replacement (no regex), so user
+# input containing &, |, \, etc. is safe.
+substitute() {
+  local src="$1"
+  local dst="$2"
+  local content
+  content=$(<"${src}")
+  content="${content//\{\{PROJECT_NAME\}\}/${PROJECT_NAME}}"
+  content="${content//\{\{PITCH\}\}/${PITCH}}"
+  content="${content//\{\{STACK\}\}/${STACK}}"
+  content="${content//\{\{TODAY\}\}/${TODAY}}"
+  printf '%s' "${content}" > "${dst}"
+}
+
+# template-name : destination-path-relative-to-target-dir
+manifest=(
+  "AGENTS.html:AGENTS.html"
+  "AGENTS-shim.md:AGENTS.md"
+  "CLAUDE-shim.md:CLAUDE.md"
+  "IMPLEMENTATION_PLAN.html:docs/IMPLEMENTATION_PLAN.html"
+  "WORKING_AGREEMENT.html:docs/WORKING_AGREEMENT.html"
+  "docs-gdd-index.html:docs/gdd/index.html"
+  "GDD_COVERAGE.json:docs/GDD_COVERAGE.json"
+  "PROGRESS_LOG.html:docs/PROGRESS_LOG.html"
+  "OPEN_QUESTIONS.html:docs/OPEN_QUESTIONS.html"
+  "FOLLOWUPS.html:docs/FOLLOWUPS.html"
+  "DEPENDENCY_LEDGER.html:docs/DEPENDENCY_LEDGER.html"
+  "PLAYTEST.html:docs/PLAYTEST.html"
+  "FUN_FACTOR_AUDIT.html:docs/FUN_FACTOR_AUDIT.html"
+  # Path-scoped Rules keep .md extension and YAML frontmatter. Claude Code's
+  # path-scoped Rules system parses the frontmatter to decide when to load.
+  # The body inside each rule is HTML.
+  "dot-claude-rules-slice-discipline.md:.claude/rules/slice-discipline.md"
+  "dot-claude-rules-ledger-append-only.md:.claude/rules/ledger-append-only.md"
+  "dot-claude-rules-gdd-build-log.md:.claude/rules/gdd-build-log.md"
+)
+
+written=()
+for entry in "${manifest[@]}"; do
+  src_name="${entry%%:*}"
+  dst_path="${entry#*:}"
+  substitute "${TEMPLATES_DIR}/${src_name}" "${TARGET_DIR}/${dst_path}"
+  written+=("${dst_path}")
+done
+
+# Codex symlinks: each .claude/rules/X.md gets a per-directory AGENTS.md
+# alias so Codex picks it up via its root-down AGENTS.md walk.
+# - docs/AGENTS.md    -> ledger-append-only (covers ledger files in docs/)
+# - docs/gdd/AGENTS.md -> gdd-build-log     (covers GDD section files)
+# slice-discipline covers source dirs that do not exist yet at init time.
+# Note: the root-level AGENTS.md is the shim that points at AGENTS.html;
+# Codex still walks into docs/ and docs/gdd/ to pick up these symlinks.
+ln -sf "../.claude/rules/ledger-append-only.md" "${TARGET_DIR}/docs/AGENTS.md"
+written+=("docs/AGENTS.md (symlink to .claude/rules/ledger-append-only.md)")
+
+ln -sf "../../.claude/rules/gdd-build-log.md" "${TARGET_DIR}/docs/gdd/AGENTS.md"
+written+=("docs/gdd/AGENTS.md (symlink to .claude/rules/gdd-build-log.md)")
+
+# Em-dash sanity check on the written files (U+2014 em-dash, U+2013 en-dash).
+if grep -lP '[\x{2014}\x{2013}]' \
+  "${TARGET_DIR}/AGENTS.html" \
+  "${TARGET_DIR}/AGENTS.md" \
+  "${TARGET_DIR}/CLAUDE.md" \
+  "${TARGET_DIR}"/docs/*.html \
+  "${TARGET_DIR}"/docs/gdd/*.html \
+  "${TARGET_DIR}"/.claude/rules/*.md \
+  2>/dev/null | grep -q .; then
+  echo
+  echo "WARNING: em-dash or en-dash detected in written files. This violates Rule 1." >&2
+  echo "         Inspect and replace before committing." >&2
+fi
+
+echo "spiral-html init complete. Wrote:"
+for f in "${written[@]}"; do
+  echo "  ${f}"
+done
+
+cat <<EOF
+
+Next steps:
+  1. Draft the first GDD section under docs/gdd/01-vision-and-pillars.html.
+  2. Replace the example rows in docs/GDD_COVERAGE.json with real atomic requirements.
+  3. Start the loop: /randroid-loop implement
+EOF

--- a/plugins/spiral-html/templates/AGENTS-shim.md
+++ b/plugins/spiral-html/templates/AGENTS-shim.md
@@ -1,0 +1,5 @@
+# AGENTS
+
+The active contract for this repository lives in [`AGENTS.html`](./AGENTS.html). Read it before writing anything.
+
+This file is a Codex compatibility shim. Codex's root-down walk expects `AGENTS.md`; the HTML-first scaffold writes the full contract to `AGENTS.html` and leaves this pointer so Codex still lands on the right doc.

--- a/plugins/spiral-html/templates/AGENTS.html
+++ b/plugins/spiral-html/templates/AGENTS.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>AGENTS: {{PROJECT_NAME}}</title>
+</head>
+<body>
+
+<header>
+  <h1>AGENTS.html</h1>
+  <p>Shared rules for every agentic coding tool working in <strong>{{PROJECT_NAME}}</strong>. Claude Code, Codex, Cursor, and any future agent: this file is mandatory reading before you write anything.</p>
+  <p><strong>Project pitch:</strong> {{PITCH}}</p>
+</header>
+
+<section data-rule-id="rule-1" data-role="rule">
+  <h2>RULE 1: NEVER USE EM-DASHES. EVER.</h2>
+  <p>No em-dashes. Not in chat. Not in code comments. Not in commit messages. Not in PR descriptions. Not in docs. Not in test names. Not anywhere.</p>
+  <p>Use a period, comma, colon, parentheses, or rewrite the sentence. En-dashes are not substitutes. Plain hyphens are fine for ranges like <code>pages 10-20</code> and compound words.</p>
+  <p>Before every tool call that writes text, scan your output for Unicode codepoints U+2014 (em-dash) and U+2013 (en-dash). Rewrite if either is present.</p>
+  <p>If porting or quoting text from another source, strip all em-dashes from the ported text before committing.</p>
+</section>
+
+<section data-rule-id="rule-2" data-role="rule">
+  <h2>RULE 2: Read the GDD before making design decisions</h2>
+  <p>The Game Design Document at <code>docs/gdd/</code> is the source of truth for what {{PROJECT_NAME}} is. Before proposing architecture, adding features, or changing data schemas, read it. If the GDD and your idea disagree, the GDD wins unless explicitly approved.</p>
+  <p>Before each implementation slice, read:</p>
+  <ul>
+    <li><code>AGENTS.html</code></li>
+    <li><code>README.md</code></li>
+    <li><code>docs/IMPLEMENTATION_PLAN.html</code></li>
+    <li><code>docs/WORKING_AGREEMENT.html</code></li>
+    <li><code>docs/gdd/</code> (the relevant requirement files)</li>
+    <li><code>docs/PROGRESS_LOG.html</code></li>
+    <li><code>docs/OPEN_QUESTIONS.html</code></li>
+    <li><code>docs/FOLLOWUPS.html</code></li>
+    <li><code>docs/GDD_COVERAGE.json</code></li>
+    <li><code>docs/DEPENDENCY_LEDGER.html</code> (and run the Dependency Upgrade Gate from <code>docs/IMPLEMENTATION_PLAN.html</code>)</li>
+    <li><code>docs/PLAYTEST.html</code> and <code>docs/FUN_FACTOR_AUDIT.html</code> when coverage is ≥80% done</li>
+    <li>the current task backlog (Dots or equivalent)</li>
+  </ul>
+
+  <h3>Path-scoped Rules</h3>
+  <p>Three additional rule files live under <code>.claude/rules/</code>. They are loaded automatically:</p>
+  <ul>
+    <li><strong>Claude Code</strong> loads them based on the <code>paths:</code> glob in their YAML frontmatter.</li>
+    <li><strong>Codex</strong> loads them via per-directory <code>AGENTS.md</code> symlinks (<code>docs/AGENTS.md</code>, <code>docs/gdd/AGENTS.md</code>) on its root-down walk.</li>
+  </ul>
+  <p>The three rules:</p>
+  <ul>
+    <li><code>.claude/rules/slice-discipline.md</code> (paths: source-code globs): no drive-by refactors, no speculative abstractions, refactor-in-slice.</li>
+    <li><code>.claude/rules/ledger-append-only.md</code> (paths: the four ledger files): never delete past entries.</li>
+    <li><code>.claude/rules/gdd-build-log.md</code> (paths: GDD section files): append a build log entry on every shipped feature.</li>
+  </ul>
+  <p>When you add a source directory (<code>src/</code>, <code>app/</code>, <code>lib/</code>, <code>components/</code>, <code>pages/</code>, <code>tests/</code>, etc.) to this project, run this once to make slice-discipline visible to Codex inside that tree:</p>
+  <pre><code>ln -sf ../.claude/rules/slice-discipline.md &lt;src-dir&gt;/AGENTS.md</code></pre>
+  <p>Claude Code already picks up slice-discipline by path glob without the symlink.</p>
+</section>
+
+<section data-rule-id="rule-3" data-role="rule">
+  <h2>RULE 3: Stack constraints</h2>
+  <p>{{STACK}}</p>
+  <p>Do not introduce new dependencies in core categories without explicit user approval.</p>
+</section>
+
+<section data-rule-id="rule-4" data-role="rule">
+  <h2>RULE 4: Commit messages and PR descriptions</h2>
+  <ul>
+    <li>Write them as a human would.</li>
+    <li>No AI attribution. No <code>Co-Authored-By: Claude</code>. No "Generated with Claude Code" footers. No mention of Claude, Anthropic, or AI assistance.</li>
+    <li>Keep them short, clean, professional. Focus on the why, not the what.</li>
+  </ul>
+</section>
+
+<section data-rule-id="rule-5" data-role="rule">
+  <h2>RULE 5: Autonomous PR loop</h2>
+  <p>Operate continuously until the planned scope is complete. The loop definition lives in <code>docs/IMPLEMENTATION_PLAN.html</code>. The process contract lives in <code>docs/WORKING_AGREEMENT.html</code>. Follow both on every slice.</p>
+  <p>For every slice:</p>
+  <ol>
+    <li>Read the rule, plan, product, progress, question, followup, coverage, dependency-ledger, and backlog documents listed in Rule 2.</li>
+    <li>Run the Dependency Upgrade Gate (see <code>docs/IMPLEMENTATION_PLAN.html</code>). If a watched dep is out of date, the upgrade IS the next slice unless red CI takes over.</li>
+    <li>Pick the highest-priority unblocked task from the implementation plan, dep ledger, GDD coverage gaps, followups, and active backlog.</li>
+    <li>Create one branch for one PR-sized slice. Never push directly to <code>main</code>.</li>
+    <li>Implement the slice fully using existing project patterns.</li>
+    <li>Add or update tests appropriate to the risk and surface area.</li>
+    <li>Update <code>docs/PROGRESS_LOG.html</code>, <code>docs/GDD_COVERAGE.json</code>, <code>docs/OPEN_QUESTIONS.html</code>, <code>docs/FOLLOWUPS.html</code>, <code>docs/DEPENDENCY_LEDGER.html</code>, and the GDD section when the work changes them.</li>
+    <li>Run the local verification suite. At minimum: dash checks, <code>git diff --check</code>, type-check, relevant unit tests, broader checks when warranted.</li>
+    <li>Re-run the Dependency Upgrade Gate before opening the PR. If a watched release landed while the slice was in flight, defer the bump to its own PR (do not bundle).</li>
+    <li>Open a PR.</li>
+    <li>Inspect all PR review comments, including inline and threaded comments from CodeRabbit or other review bots.</li>
+    <li>Fix actionable review comments, reply in-thread when the platform supports it, resolve threads when resolved.</li>
+    <li>After every push to the PR branch, wait for any configured bot reviewer to finish its review pass. The wait is settled only when all required checks are green AND at least 60 seconds have passed since the latest PR branch push or latest bot review activity, whichever is later. Re-inspect reviews and review threads after the settled wait.</li>
+    <li>Wait for CI and the preview deploy to pass.</li>
+    <li>Merge only when green, review feedback is handled, bot review has settled, and the preview deploy is healthy.</li>
+    <li>Pull <code>main</code>, verify main CI and production deploy, smoke test production.</li>
+    <li>Close the completed backlog item with the PR number and verification.</li>
+    <li>Immediately start the next slice.</li>
+  </ol>
+  <p>Do not stop at planning. Do not stop after opening a PR. Do not stop after merge. If blocked, log the blocker, update the backlog item, move to the next unblocked slice.</p>
+  <p>Never mark work complete with failing tests, unresolved actionable review comments, a bot review still in flight after the latest push, red CI, or a broken deploy.</p>
+</section>
+
+<section data-rule-id="rule-6" data-role="rule">
+  <h2>RULE 6: Destructive and shared-system actions</h2>
+  <p>Always confirm with the user before:</p>
+  <ul>
+    <li><code>git push --force</code>, <code>git reset --hard</code>, <code>rm -rf</code>, dropping data stores, deleting files or branches.</li>
+    <li>Direct pushes to <code>main</code> or any protected branch.</li>
+    <li>Modifying CI/CD configuration.</li>
+    <li>Uploading content to third-party services.</li>
+  </ul>
+  <p>Prior approval for one destructive action is not approval for all of them. Ask each time.</p>
+</section>
+
+<section data-rule-id="rule-7" data-role="rule">
+  <h2>RULE 7: When in doubt, ask. And prefer simple consistent flows.</h2>
+  <ul>
+    <li>When a UX decision could go branchy (different behavior per route, per state, per user), default to one consistent rule across all cases.</li>
+    <li>Always explain why you are prompting the user for input.</li>
+    <li>If requirements are ambiguous and a reasonable default would be risky, ask. Otherwise choose the simplest consistent path, document the assumption in <code>docs/OPEN_QUESTIONS.html</code> with a <code>Recommended default</code> entry, ship under that default, and keep moving.</li>
+  </ul>
+</section>
+
+<section data-rule-id="rule-8" data-role="rule">
+  <h2>RULE 8: Secrets and environment variables</h2>
+  <ul>
+    <li>Never commit <code>.env</code>, <code>.env.local</code>, or any file containing credentials.</li>
+    <li>Never print secret values in logs, chat, or commit messages.</li>
+    <li>Document expected env vars in <code>README.md</code>. Set them in the deployment dashboard, not in the repo.</li>
+  </ul>
+</section>
+
+<section data-rule-id="rule-9" data-role="rule">
+  <h2>RULE 9: Testing expectations</h2>
+  <ul>
+    <li>New pure logic must have unit tests.</li>
+    <li>New API routes must have at least one route-handler test plus one smoke test.</li>
+    <li>Do not mark a task complete with failing tests.</li>
+  </ul>
+</section>
+
+<section data-rule-id="rule-10" data-role="rule">
+  <h2>RULE 10: Motion and overlay QA</h2>
+  <p>When adding auto-scrolling, credits, animated overlays, portals, or modal UI:</p>
+  <ul>
+    <li>Verify the visible pixels move, not just that a control says the animation is active.</li>
+    <li>Add coverage that measures a changing DOM rect, transform, canvas pixel, or other observable movement over time.</li>
+    <li>Do not pause auto-motion on focus by default. Focus can happen on mount and silently disable the feature.</li>
+    <li>For modal overlays, set z-index above every fixed interactive app surface and confirm background controls cannot sit above the dialog.</li>
+    <li>Preserve normal keyboard activation on focused buttons and form controls.</li>
+    <li>Expose toggle state with <code>aria-pressed</code> or equivalent accessible state.</li>
+  </ul>
+</section>
+
+<section data-rule-id="rule-11" data-role="rule">
+  <h2>RULE 11: One backing store per project</h2>
+  <p>Every Vercel project gets its own dedicated storage resources. Never share an Upstash KV, Postgres, Blob, or any other backing store across projects, even when key-prefix or schema namespacing would prevent collisions.</p>
+  <p>Why:</p>
+  <ul>
+    <li>Shared rate limits. One project's runaway loop pressures the other's ceiling.</li>
+    <li>Shared billing. Cost attribution becomes impossible.</li>
+    <li>Shared rotation. A token leak in one project forces every co-tenant to redeploy.</li>
+    <li>Shared blast radius on outages. A misconfigured PUT in one project can fill the other's storage budget.</li>
+  </ul>
+  <p>How:</p>
+  <ul>
+    <li>Provision storage via the Vercel marketplace UI before wiring code that needs it. The CLI does not expose marketplace provisioning; this is one of the few setup steps that lives in the dashboard.</li>
+    <li>After provisioning, attach the resource to exactly one Vercel project. Never use <code>vercel env add</code> to copy another project's connection string into this project.</li>
+    <li>The first env vars on a fresh project should come from the project's own provisioned store, not from another project's <code>.env.local</code>.</li>
+    <li>Local dev pulls from the project's own Vercel env via <code>vercel env pull</code> (which respects the project link in <code>.vercel/project.json</code>).</li>
+  </ul>
+  <p>If you find yourself about to run <code>vercel env add KV_REST_API_URL</code> with a value that came from another project's env, stop. Provision a dedicated store first.</p>
+</section>
+
+<section data-role="checklist" id="pre-commit-checklist">
+  <h2>Quick pre-commit checklist</h2>
+  <ol>
+    <li>No em-dashes. Run <code>grep -rnP '[\x{2014}\x{2013}]' .</code> (checks for U+2014 em-dash and U+2013 en-dash). Must return nothing.</li>
+    <li>No AI attribution in the commit message.</li>
+    <li>Tests pass locally.</li>
+    <li>GDD is still accurate, or updated.</li>
+    <li>No secrets in the diff.</li>
+  </ol>
+</section>
+
+</body>
+</html>

--- a/plugins/spiral-html/templates/CLAUDE-shim.md
+++ b/plugins/spiral-html/templates/CLAUDE-shim.md
@@ -1,0 +1,5 @@
+# CLAUDE
+
+The active contract for this repository lives in [`AGENTS.html`](./AGENTS.html). Read it before writing anything.
+
+This file is a Claude Code compatibility shim. Claude Code's project memory import expects `CLAUDE.md`; the HTML-first scaffold writes the full contract to `AGENTS.html` and leaves this pointer so Claude Code still lands on the right doc.

--- a/plugins/spiral-html/templates/DEPENDENCY_LEDGER.html
+++ b/plugins/spiral-html/templates/DEPENDENCY_LEDGER.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Dependency Ledger: {{PROJECT_NAME}}</title>
+</head>
+<body>
+
+<header>
+  <h1>Dependency Ledger</h1>
+  <p>Watched dependencies for <strong>{{PROJECT_NAME}}</strong>. The agent runs the <strong>Dependency Upgrade Gate</strong> (see <a href="IMPLEMENTATION_PLAN.html#dependency-upgrade-gate"><code>docs/IMPLEMENTATION_PLAN.html</code></a>) at two trigger points:</p>
+  <ol>
+    <li><strong>After every push to <code>main</code></strong> (after step 16 of the loop: pulled main, verified production), before picking the next slice.</li>
+    <li><strong>Before opening a new PR</strong> (just before step 10 of the loop), so the new branch starts from a fresh-deps baseline.</li>
+  </ol>
+  <p>If a watched dep has a newer release than the version pinned in this ledger, the upgrade is the next slice (unless step 1 of slice selection in <code>IMPLEMENTATION_PLAN.html</code> takes over: red CI, broken <code>main</code>, or a P0 incident).</p>
+</header>
+
+<section id="watch-list">
+  <h2>Watch list</h2>
+  <p>Add one entry per watched dep. Remove an entry when the project no longer depends on it. Update the <strong>Currently pinned</strong> value in the same PR that bumps the version.</p>
+  <p>Per-dep entry shape:</p>
+  <dl>
+    <dt>Name</dt><dd>package or repo identifier.</dd>
+    <dt>Why watched</dt><dd>one sentence explaining why this dep is on the ledger (internally maintained, framework major, security-sensitive, prior breakage).</dd>
+    <dt>Source</dt><dd>where to look for the latest version (npm registry URL, GitHub releases page, git tags).</dd>
+    <dt>Pin format</dt><dd>how the project pins (npm semver, github tag, git ref, file path).</dd>
+    <dt>Currently pinned</dt><dd>the version on <code>main</code> right now. Update on every successful upgrade.</dd>
+    <dt>Detect-new</dt><dd>command or URL the agent uses to discover new releases.</dd>
+    <dt>Migration notes</dt><dd>per-dep gotchas the agent should expect during upgrades.</dd>
+  </dl>
+
+  <article data-dep="@randroids-dojo/vibekit">
+    <h3>Example: <code>@randroids-dojo/vibekit</code></h3>
+    <dl>
+      <dt>Name</dt><dd><code>@randroids-dojo/vibekit</code></dd>
+      <dt>Why watched</dt><dd>internally maintained, pre-1.0, breaking changes possible on every release.</dd>
+      <dt>Source</dt><dd><a href="https://github.com/Randroids-Dojo/VibeKit/releases">https://github.com/Randroids-Dojo/VibeKit/releases</a></dd>
+      <dt>Pin format</dt><dd><code>github:Randroids-Dojo/VibeKit#vX.Y.Z</code> (tag-pinned)</dd>
+      <dt>Currently pinned</dt><dd><code>v0.1.0</code></dd>
+      <dt>Detect-new</dt><dd><code>gh api repos/Randroids-Dojo/VibeKit/releases/latest --jq .tag_name</code></dd>
+      <dt>Bootstrap / cookbook</dt><dd>the <code>vibekit</code> skill supplies <code>/vibekit add</code> (pins the dep, prints this ledger entry) and <code>/vibekit cookbook</code> (per-module wire-up patterns: joystick, editor-history, confetti, rng, math, storage, server kv/sign/rate-limit). Optional companion to spiral-html.</dd>
+      <dt>Migration notes</dt><dd>
+        <ul>
+          <li>The kit is pre-1.0; any release may break callers (release-please uses <code>bump-patch-for-minor-pre-major</code>, so feat-level changes still ship as patches and may carry signature changes).</li>
+          <li>Read the kit's <code>CHANGELOG.md</code> between the pinned and target tag.</li>
+          <li>Type errors usually surface in <code>pnpm type-check</code>; runtime regressions in unit tests + the targeted Playwright smoke for any UI that touches the kit.</li>
+          <li>For wire-up patterns (especially when a kit module's signature shifts), consult <code>/vibekit cookbook &lt;module&gt;</code> rather than re-reading the kit's full README.</li>
+        </ul>
+      </dd>
+    </dl>
+  </article>
+</section>
+
+<section id="upgrade-procedure">
+  <h2>Upgrade procedure</h2>
+  <p>Run this once per dep that has a newer release. Each upgrade is one PR.</p>
+
+  <section data-step="0">
+    <h3>0. Skip rule</h3>
+    <p>If a higher-priority slice is in flight (red CI, P0 incident, broken <code>main</code>, broken deploy), defer the upgrade and add a backlog item for it. Do not mix dep-bumps into unrelated slices.</p>
+  </section>
+
+  <section data-step="1">
+    <h3>1. Detect the new version</h3>
+    <p>Run the dep's <strong>Detect-new</strong> command. Compare to the <strong>Currently pinned</strong> value in this ledger. If equal, the gate passes; pick a regular slice. If newer, continue.</p>
+  </section>
+
+  <section data-step="2">
+    <h3>2. Read the upstream CHANGELOG</h3>
+    <p>Open the dep's CHANGELOG (or release notes) between the pinned and target version. List every breaking change, deprecation, and behavior shift. The agent must understand what migrations the bump implies BEFORE editing project code.</p>
+  </section>
+
+  <section data-step="3">
+    <h3>3. Branch</h3>
+    <p>Branch name: <code>chore/deps/&lt;dep-short-name&gt;-&lt;from&gt;-to-&lt;to&gt;</code> (example: <code>chore/deps/vibekit-0.1.0-to-0.1.4</code>). One dep per branch.</p>
+  </section>
+
+  <section data-step="4">
+    <h3>4. Bump the pin</h3>
+    <p>Update <code>package.json</code> (or the project's equivalent) with the new version. Update the <strong>Currently pinned</strong> entry in this ledger to match. Run the project's lockfile-refresh command (<code>pnpm install</code>, <code>npm install</code>, <code>cargo update -p &lt;name&gt;</code>, etc.).</p>
+  </section>
+
+  <section data-step="5">
+    <h3>5. Type-check</h3>
+    <p>Run the project's type-check command. If it fails:</p>
+    <ul>
+      <li>If the failures look like trivial signature shifts the agent can fix in this PR, do so. Each fix is its own commit (or two: type-error fix + lockfile/pin bump). Re-run type-check until it passes.</li>
+      <li>If the failures point to a deeper migration (rename of a public API, dropped feature, restructured option object) that does NOT fit in one PR, <strong>abort</strong>:
+        <ul>
+          <li>Revert the pin change.</li>
+          <li>Open an <code>F-NNN</code> followup in <code>docs/FOLLOWUPS.html</code> describing the migration work.</li>
+          <li>Add a Dot for the migration work.</li>
+          <li>Resume the regular loop without the bump.</li>
+        </ul>
+      </li>
+    </ul>
+    <p>The decision rule: a single dep upgrade PR may contain mechanical migrations (renames, option shape changes), but it must not contain new feature work or unrelated refactors. If the migration would force unrelated changes, split.</p>
+  </section>
+
+  <section data-step="6">
+    <h3>6. Run the test suite</h3>
+    <p>Project-appropriate command. Same decision rule as type-check: trivial fixes belong in the bump PR, deep migrations go in their own PR with the bump deferred.</p>
+  </section>
+
+  <section data-step="7">
+    <h3>7. Build</h3>
+    <p>Run the production build command before opening the PR if the dep affects runtime code (any client-facing code, server routes, middleware).</p>
+  </section>
+
+  <section data-step="8">
+    <h3>8. Smoke test</h3>
+    <p>Run the project's Playwright (or equivalent) smoke when the dep affects UI / API routes / core gameplay flows. Specifically: the smoke for any feature that imports from the upgraded dep.</p>
+  </section>
+
+  <section data-step="9">
+    <h3>9. Open the PR</h3>
+    <ul>
+      <li><strong>Title</strong>: <code>chore(deps): bump &lt;dep&gt; from &lt;from&gt; to &lt;to&gt;</code> (Conventional Commit <code>chore(deps):</code> so any release-please-driven downstream knows this is non-releasable).</li>
+      <li><strong>Body</strong> must include:
+        <ul>
+          <li>Direct link to the upstream CHANGELOG between the two versions.</li>
+          <li>List of breaking changes that applied to this project.</li>
+          <li>Migrations applied, one paragraph each.</li>
+          <li>Verification commands run (dash check, type-check, test, build, smoke).</li>
+          <li>The new <strong>Currently pinned</strong> value, mirroring the entry in this ledger.</li>
+        </ul>
+      </li>
+    </ul>
+  </section>
+
+  <section data-step="10">
+    <h3>10. Merge through the standard flow</h3>
+    <p>CI green, bot review settled, preview deploy green, then merge. Pull <code>main</code>. Verify production deploy. Smoke test production for the touched flows.</p>
+  </section>
+
+  <section data-step="11">
+    <h3>11. Close out</h3>
+    <p>Update the <strong>Currently pinned</strong> entry if the merge changed it (the bump PR should already do this; double-check). Append a <code>PROGRESS_LOG.html</code> entry. If the bump revealed deferred migration work, leave the <code>F-NNN</code> followups open.</p>
+  </section>
+</section>
+
+<section id="when-to-add">
+  <h2>When to add a dep to this ledger</h2>
+  <p>Add when:</p>
+  <ul>
+    <li>The dep is <strong>internally maintained</strong> (sibling repo, in-house package). Internal deps ship breaking changes the project actively needs to adopt.</li>
+    <li>The dep is <strong>critical infrastructure</strong>: framework major (Next.js, React major), runtime major (Node, Deno, Bun), security-sensitive lib (auth, crypto, signed-token).</li>
+    <li>A dep has <strong>bitten this project before</strong> with an unexpected breakage at upgrade time.</li>
+  </ul>
+  <p>Do <strong>not</strong> add commodity deps whose major-version cadence is slow (one upgrade per year or longer) and whose minor versions are rarely breaking. Those go through standard semver-range / lockfile churn (Renovate / Dependabot). The ledger is for deps the agent must consciously think about every time <code>main</code> moves.</p>
+</section>
+
+</body>
+</html>

--- a/plugins/spiral-html/templates/FOLLOWUPS.html
+++ b/plugins/spiral-html/templates/FOLLOWUPS.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Followups</title>
+</head>
+<body>
+
+<header>
+  <h1>Followups</h1>
+  <p>Backlog spillover discovered during implementation. Keep items PR-sized when possible.</p>
+  <aside data-role="convention">
+    <strong>Critical convention.</strong> Every followup must carry a <code>data-priority</code> attribute. Three buckets:
+    <ul>
+      <li><code>blocks-release</code>: cannot ship v1 without this.</li>
+      <li><code>nice-to-have</code>: improves the product but does not block.</li>
+      <li><code>polish</code>: post-release cleanup.</li>
+    </ul>
+  </aside>
+</header>
+
+<section id="how-to-add" data-role="entry-template">
+  <h2>How to add a followup</h2>
+  <pre><code>&lt;section data-f="F-NNN" data-priority="blocks-release|nice-to-have|polish"&gt;
+  &lt;h3&gt;F-NNN: Short title&lt;/h3&gt;
+  &lt;dl&gt;
+    &lt;dt&gt;Context&lt;/dt&gt;&lt;dd&gt;one or two sentences on why this came up.&lt;/dd&gt;
+    &lt;dt&gt;Blocker (if any)&lt;/dt&gt;&lt;dd&gt;the condition that prevents working on this now.&lt;/dd&gt;
+    &lt;dt&gt;Unblock condition&lt;/dt&gt;&lt;dd&gt;what has to be true to start.&lt;/dd&gt;
+    &lt;dt&gt;PR / Dot reference&lt;/dt&gt;&lt;dd&gt;#N or dots-N (when picked up)&lt;/dd&gt;
+  &lt;/dl&gt;
+&lt;/section&gt;</code></pre>
+  <p>Keep <code>F-NNN</code> IDs monotonically increasing. When a followup ships, leave the entry in place and append a <code>&lt;dt&gt;Resolved&lt;/dt&gt;&lt;dd&gt;PR #N&lt;/dd&gt;</code> entry. Never delete.</p>
+</section>
+
+<main id="blocks-release">
+  <h2>Blocks Release</h2>
+  <p>(none yet)</p>
+</main>
+
+<main id="nice-to-have">
+  <h2>Nice To Have</h2>
+
+  <section data-f="F-001" data-priority="nice-to-have">
+    <h3>F-001: Draft first GDD section</h3>
+    <dl>
+      <dt>Context</dt><dd>scaffold landed; the seed <code>docs/gdd/01-vision-and-pillars.html</code> has not been drafted yet.</dd>
+      <dt>Blocker</dt><dd>none.</dd>
+      <dt>Unblock condition</dt><dd>dev provides one paragraph of vision text or approves a draft.</dd>
+    </dl>
+  </section>
+
+</main>
+
+<main id="polish">
+  <h2>Polish</h2>
+  <p>(none yet)</p>
+</main>
+
+</body>
+</html>

--- a/plugins/spiral-html/templates/FOLLOWUPS.html
+++ b/plugins/spiral-html/templates/FOLLOWUPS.html
@@ -33,12 +33,13 @@
   <p>Keep <code>F-NNN</code> IDs monotonically increasing. When a followup ships, leave the entry in place and append a <code>&lt;dt&gt;Resolved&lt;/dt&gt;&lt;dd&gt;PR #N&lt;/dd&gt;</code> entry. Never delete.</p>
 </section>
 
-<main id="blocks-release">
+<main>
+<section id="blocks-release">
   <h2>Blocks Release</h2>
   <p>(none yet)</p>
-</main>
+</section>
 
-<main id="nice-to-have">
+<section id="nice-to-have">
   <h2>Nice To Have</h2>
 
   <section data-f="F-001" data-priority="nice-to-have">
@@ -47,14 +48,16 @@
       <dt>Context</dt><dd>scaffold landed; the seed <code>docs/gdd/01-vision-and-pillars.html</code> has not been drafted yet.</dd>
       <dt>Blocker</dt><dd>none.</dd>
       <dt>Unblock condition</dt><dd>dev provides one paragraph of vision text or approves a draft.</dd>
+      <dt>PR / Dot reference</dt><dd>(not started)</dd>
     </dl>
   </section>
 
-</main>
+</section>
 
-<main id="polish">
+<section id="polish">
   <h2>Polish</h2>
   <p>(none yet)</p>
+</section>
 </main>
 
 </body>

--- a/plugins/spiral-html/templates/FUN_FACTOR_AUDIT.html
+++ b/plugins/spiral-html/templates/FUN_FACTOR_AUDIT.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Fun Factor Gap Audit</title>
+</head>
+<body>
+
+<header>
+  <h1>Fun Factor Gap Audit</h1>
+  <aside data-role="gate">
+    <strong>Backlog generator.</strong> Run this audit when <code>docs/GDD_COVERAGE.json</code> is ≥80% <code>done</code>. Re-run after every major system lands. This is the source of the P0 / P1 polish work that prevents the loop from terminating before the product is good. Each gap identified here becomes a <code>Q-NNN</code> open question or an <code>F-NNN</code> followup.
+    <p>This doc exists because the Flatline failure mode is: every coverage row is <code>done</code>, every test passes, every checkbox is green, but the product is not actually fun. Coverage rows say a <em>system</em> exists. They cannot say the system <em>delivers experience</em>. This audit asks the questions coverage cannot.</p>
+  </aside>
+</header>
+
+<section id="how-to-run">
+  <h2>How to run an audit</h2>
+  <ol>
+    <li>Set today's date as the audit header (<code>&lt;article data-audit-date="YYYY-MM-DD"&gt;</code>).</li>
+    <li>Walk each prompt below. Write a one-sentence answer for each. Be honest. "Yes" answers do not generate work; gaps do.</li>
+    <li>For each gap, decide: is this a question (<code>Q-NNN</code>) or a followup (<code>F-NNN</code>)?</li>
+    <li>Add the entry. Reference the audit date in the entry's Context line.</li>
+    <li>Save the audit. Do not delete previous audits; let the file grow.</li>
+  </ol>
+  <p>Append-only. Earlier audits are preserved.</p>
+</section>
+
+<section id="prompts">
+  <h2>Prompts</h2>
+
+  <section data-prompt-group="first-session">
+    <h3>The first session</h3>
+    <ul>
+      <li>Does the first 90 seconds make the player want to keep playing?</li>
+      <li>What is the first specific moment that surprises a new user (positive or negative)?</li>
+      <li>Where does a new user get stuck or confused?</li>
+    </ul>
+  </section>
+
+  <section data-prompt-group="core-action">
+    <h3>The core action</h3>
+    <ul>
+      <li>Does the core action feel good at every skill level (novice, mid, expert)?</li>
+      <li>Is there meaningful skill expression? Can two players visibly perform differently at the same task?</li>
+      <li>Does the core action have texture (light cues, weight, follow-through), or does it feel binary?</li>
+    </ul>
+  </section>
+
+  <section data-prompt-group="variety">
+    <h3>Variety</h3>
+    <ul>
+      <li>Do the variations within the system feel distinct, or do they feel like recolors?</li>
+      <li>If the player picks a "different" option (track / character / mode / layout), do they have a different experience?</li>
+      <li>Is there a surprise still waiting for a player who has played for an hour?</li>
+    </ul>
+  </section>
+
+  <section data-prompt-group="difficulty-arc">
+    <h3>Difficulty arc</h3>
+    <ul>
+      <li>Where is the difficulty too high (frustration without learning)?</li>
+      <li>Where is the difficulty too low (boredom)?</li>
+      <li>Is there a clear "I want to keep going to get better" pull?</li>
+    </ul>
+  </section>
+
+  <section data-prompt-group="stickiness">
+    <h3>Stickiness</h3>
+    <ul>
+      <li>What brings a player back the next day?</li>
+      <li>What makes a player tell a friend about this?</li>
+      <li>What is the smallest change that would meaningfully improve retention?</li>
+    </ul>
+  </section>
+
+  <section data-prompt-group="polish-postponed">
+    <h3>Polish you have been postponing</h3>
+    <ul>
+      <li>List up to five "we know this needs work" items you have been quietly avoiding. Be specific.</li>
+      <li>For each, name the smallest slice that would meaningfully address it.</li>
+    </ul>
+  </section>
+</section>
+
+<section id="audit-log">
+  <h2>Audit log</h2>
+
+  <article data-audit-date="{{TODAY}}" data-audit-state="initial">
+    <h3>Audit {{TODAY}} (initial)</h3>
+    <p>(populate when first run, after at least one full system has landed and coverage is non-trivial)</p>
+  </article>
+
+  <aside id="earlier-audits">
+    <h3>Earlier audits</h3>
+    <p>(append previous audits below this line as they age out, newest above oldest)</p>
+  </aside>
+</section>
+
+</body>
+</html>

--- a/plugins/spiral-html/templates/GDD_COVERAGE.json
+++ b/plugins/spiral-html/templates/GDD_COVERAGE.json
@@ -1,0 +1,25 @@
+{
+  "_comment_1": "ATOMIC GRANULARITY ONLY. One row per requirement, not per chapter. A 14-day project should produce on the order of 100 rows. If your row count is implausibly low for project age, the loop will self-terminate before the product is good. This is the Flatline failure mode.",
+  "_comment_2": "Allowed status values: not_started | partial | done. Every row should carry implementationRefs and testRefs once status >= partial. followupRefs link to F-NNN entries in FOLLOWUPS.html.",
+  "updatedAt": "{{TODAY}}",
+  "rows": [
+    {
+      "id": "REQ-001",
+      "requirement": "Player can do <atomic-thing>",
+      "gddRef": "docs/gdd/02-core-loop.html#section-anchor",
+      "status": "not_started",
+      "implementationRefs": [],
+      "testRefs": [],
+      "followupRefs": []
+    },
+    {
+      "id": "REQ-002",
+      "requirement": "System emits <atomic-event> when <atomic-condition>",
+      "gddRef": "docs/gdd/02-core-loop.html#another-anchor",
+      "status": "not_started",
+      "implementationRefs": [],
+      "testRefs": [],
+      "followupRefs": []
+    }
+  ]
+}

--- a/plugins/spiral-html/templates/IMPLEMENTATION_PLAN.html
+++ b/plugins/spiral-html/templates/IMPLEMENTATION_PLAN.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Implementation Plan: {{PROJECT_NAME}}</title>
+</head>
+<body>
+
+<header>
+  <h1>Implementation Plan</h1>
+  <p>This document is the main operating loop for <strong>{{PROJECT_NAME}}</strong> implementation. Agents must keep working continuously until the planned scope is complete.</p>
+</header>
+
+<section id="loop-contract">
+  <h2>Loop Contract</h2>
+  <p>Every slice follows the same loop:</p>
+  <ol>
+    <li>Read <code>AGENTS.html</code>, <code>README.md</code>, this plan, <code>docs/WORKING_AGREEMENT.html</code>, the relevant <code>docs/gdd/</code> files, <code>docs/PROGRESS_LOG.html</code>, <code>docs/OPEN_QUESTIONS.html</code>, <code>docs/FOLLOWUPS.html</code>, <code>docs/GDD_COVERAGE.json</code>, <code>docs/DEPENDENCY_LEDGER.html</code>, and the active backlog.</li>
+    <li><strong>Run the Dependency Upgrade Gate</strong> (see below). If a watched dep is out of date, the upgrade is the next slice unless step 1 of slice selection (broken main / red CI) takes over.</li>
+    <li>Pick the highest-priority unblocked task from this plan, coverage gaps, followups, the qualitative-gate docs, and the active backlog.</li>
+    <li>Create one branch for one PR-sized slice.</li>
+    <li>Build the slice completely using existing code patterns.</li>
+    <li>Add or update tests for the touched behavior.</li>
+    <li>Update continuity docs and the GDD coverage ledger.</li>
+    <li>Run local verification.</li>
+    <li><strong>Re-run the Dependency Upgrade Gate</strong> before opening the PR. If a watched dep landed a new release while the slice was in flight, defer it to a separate PR (do not bundle into this one); log the bump as the next slice.</li>
+    <li>Open a PR.</li>
+    <li>Inspect review comments and threaded inline comments.</li>
+    <li>Fix actionable feedback, reply when useful, resolve threads.</li>
+    <li>After every push to the PR branch, wait for any configured bot reviewer to finish its review pass, then re-inspect reviews and threaded comments. The wait is settled only when all required checks are green AND at least 60 seconds have passed since the latest PR branch push or latest bot review activity, whichever is later. If no fresh bot review appears after that, record that no new bot feedback was posted after the push.</li>
+    <li>Wait for CI and preview deploy to pass.</li>
+    <li>Merge only when green and bot review has settled after the latest push.</li>
+    <li>Pull <code>main</code>, verify main CI and production deploy, smoke test production.</li>
+    <li>Close the backlog item with the PR number and verification evidence.</li>
+    <li>Immediately start the next slice.</li>
+  </ol>
+  <p>Do not stop after planning, after opening a PR, or after merging. If a task is blocked, log the blocker in <code>docs/OPEN_QUESTIONS.html</code> or <code>docs/FOLLOWUPS.html</code>, update the backlog item, and move to the next unblocked slice.</p>
+</section>
+
+<section id="dependency-upgrade-gate">
+  <h2>Dependency Upgrade Gate</h2>
+  <p>Run at two points in the loop:</p>
+  <ul>
+    <li><strong>After step 16</strong> (just landed on fresh <code>main</code>), before picking the next slice.</li>
+    <li><strong>Before step 10</strong> (opening a PR), to catch new releases that landed while the slice was in flight.</li>
+  </ul>
+  <p>Read <code>docs/DEPENDENCY_LEDGER.html</code>. For every watched dep, run its <strong>Detect-new</strong> command and compare against the ledger's <strong>Currently pinned</strong> value. If a newer release exists:</p>
+  <ol>
+    <li>The upgrade IS the next slice unless slice selection priority 1 (red CI / broken main) takes over.</li>
+    <li>Follow the per-dep procedure in <code>docs/DEPENDENCY_LEDGER.html</code> §<a href="DEPENDENCY_LEDGER.html#upgrade-procedure">Upgrade procedure</a>: branch, bump, type-check, test, build, smoke, PR.</li>
+    <li>If the upgrade requires a migration that cannot land in one PR, abort the bump, log an <code>F-NNN</code> followup for the migration work, and continue with the prior pin. Add a Dot for the migration work.</li>
+    <li>The bump PR updates the ledger's <strong>Currently pinned</strong> line in the same diff that bumps the package manifest. The two must move together.</li>
+  </ol>
+  <p>The gate is mechanical, not optional. A new pinned tag is the same kind of "fresh state" that a new commit on <code>main</code> is: the agent must observe and react.</p>
+</section>
+
+<section id="slice-selection">
+  <h2>Slice Selection</h2>
+  <p>Priority order:</p>
+  <ol>
+    <li>Broken <code>main</code>, red CI, broken deploy, or failing required checks.</li>
+    <li><strong>Pending dependency upgrades from <code>docs/DEPENDENCY_LEDGER.html</code>.</strong></li>
+    <li>Active P0 or P1 backlog items.</li>
+    <li>Open <code>docs/OPEN_QUESTIONS.html</code> entries that block implementation and have enough information to resolve.</li>
+    <li>High-priority <code>docs/FOLLOWUPS.html</code> items.</li>
+    <li><code>docs/GDD_COVERAGE.json</code> gaps marked <code>not_started</code> or <code>partial</code>.</li>
+    <li>GDD requirements with user-visible scope still marked partial.</li>
+    <li><strong>Once coverage is ≥80% done:</strong> open items in <code>docs/PLAYTEST.html</code> and gaps in <code>docs/FUN_FACTOR_AUDIT.html</code>. These are the second gate. The loop is not finished until these resolve.</li>
+    <li>Cleanup that removes blockers, stale docs, or brittle test gaps.</li>
+  </ol>
+  <p>Prefer the smallest slice that creates a useful PR. Avoid mixing unrelated work.</p>
+</section>
+
+<section id="definition-of-done">
+  <h2>Definition Of Done</h2>
+  <p>A slice is done only when all apply:</p>
+  <ul>
+    <li>Code, docs, tests, and coverage ledger match the implemented behavior.</li>
+    <li>Required local verification passes.</li>
+    <li>PR is open and all actionable review comments are handled.</li>
+    <li>Bot review has finished after the latest push, or no fresh bot feedback appeared after the settled wait.</li>
+    <li>CI and preview deploy are green.</li>
+    <li>PR is merged.</li>
+    <li>Local <code>main</code> is updated from remote.</li>
+    <li>Main CI and production deploy are green.</li>
+    <li>Production smoke test passes or a blocker is logged.</li>
+    <li>The backlog item or followup is closed with the PR number and verification.</li>
+  </ul>
+</section>
+
+<section id="project-closure">
+  <h2>Project Closure</h2>
+  <p>The loop ends when ALL apply:</p>
+  <ol>
+    <li>Every row in <code>docs/GDD_COVERAGE.json</code> is <code>done</code> with implementation and test refs.</li>
+    <li>Every checklist item in <code>docs/PLAYTEST.html</code> is checked or explicitly deferred to a follow-up release.</li>
+    <li><code>docs/FUN_FACTOR_AUDIT.html</code> has been re-run after the last system landed and produced no new P0 or P1 gaps.</li>
+  </ol>
+  <p>Closing the loop without all three is the Flatline failure mode: shipping a complete-on-paper system that is not actually good.</p>
+</section>
+
+<section id="current-planned-scope">
+  <h2>Current Planned Scope</h2>
+  <p>Use <code>docs/gdd/</code> as the product scope. The current high-level remaining areas are reflected in <code>docs/GDD_COVERAGE.json</code>, with active spillover in <code>docs/FOLLOWUPS.html</code>.</p>
+</section>
+
+</body>
+</html>

--- a/plugins/spiral-html/templates/OPEN_QUESTIONS.html
+++ b/plugins/spiral-html/templates/OPEN_QUESTIONS.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Open Questions</title>
+</head>
+<body>
+
+<header>
+  <h1>Open Questions</h1>
+  <p>Questions here block or influence implementation.</p>
+  <aside data-role="convention">
+    <strong>Critical convention.</strong> Every question must include a <code>&lt;dt&gt;Recommended default&lt;/dt&gt;</code> entry. The loop ships under that default and leaves the question open for override. Do not block the loop on dev sign-off. Stress-tested values that survive multiple iterations get frozen.
+  </aside>
+</header>
+
+<section id="how-to-add" data-role="entry-template">
+  <h2>How to add a new question</h2>
+  <pre><code>&lt;section data-q="Q-NNN" data-status="open"&gt;
+  &lt;h3&gt;Q-NNN: Short title&lt;/h3&gt;
+  &lt;dl&gt;
+    &lt;dt&gt;Context&lt;/dt&gt;&lt;dd&gt;one or two sentences on why this is a decision point.&lt;/dd&gt;
+    &lt;dt&gt;Options&lt;/dt&gt;&lt;dd&gt;
+      &lt;ol type="A"&gt;
+        &lt;li&gt;Option A description.&lt;/li&gt;
+        &lt;li&gt;Option B description.&lt;/li&gt;
+        &lt;li&gt;Option C description.&lt;/li&gt;
+      &lt;/ol&gt;
+    &lt;/dd&gt;
+    &lt;dt&gt;Recommended default&lt;/dt&gt;&lt;dd&gt;B. One sentence on the rationale.&lt;/dd&gt;
+    &lt;dt&gt;Status&lt;/dt&gt;&lt;dd&gt;open&lt;/dd&gt;
+    &lt;dt&gt;Resolution&lt;/dt&gt;&lt;dd&gt;(filled in once dev confirms or overrides)&lt;/dd&gt;
+  &lt;/dl&gt;
+&lt;/section&gt;</code></pre>
+  <p>Keep <code>Q-NNN</code> IDs monotonically increasing. When a question resolves, leave the entry in place and update <code>data-status</code> to <code>resolved</code> plus the <code>Resolution</code> entry. Never delete.</p>
+</section>
+
+<main id="open">
+  <h2>Open</h2>
+
+  <section data-q="Q-001" data-status="open">
+    <h3>Q-001: First requirement file</h3>
+    <dl>
+      <dt>Context</dt><dd>which GDD section to draft first as the seed for the coverage ledger.</dd>
+      <dt>Options</dt><dd>
+        <ol type="A">
+          <li><code>01-vision-and-pillars.html</code> (the abstract framing).</li>
+          <li>The first concrete user-visible feature.</li>
+          <li>The data model / persistence layer.</li>
+        </ol>
+      </dd>
+      <dt>Recommended default</dt><dd>A. The pillars file is short, drives every subsequent decision, and unblocks the rest.</dd>
+      <dt>Status</dt><dd>open</dd>
+      <dt>Resolution</dt><dd></dd>
+    </dl>
+  </section>
+
+</main>
+
+<aside id="resolved">
+  <h2>Resolved</h2>
+  <p>(none yet)</p>
+</aside>
+
+</body>
+</html>

--- a/plugins/spiral-html/templates/PLAYTEST.html
+++ b/plugins/spiral-html/templates/PLAYTEST.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Release Playtest Checklist</title>
+</head>
+<body>
+
+<header>
+  <h1>Release Playtest Checklist</h1>
+  <aside data-role="gate">
+    <strong>The second gate.</strong> When all coverage rows in <code>docs/GDD_COVERAGE.json</code> are <code>done</code>, this checklist becomes the active backlog. The loop is not finished until every item here is checked or explicitly deferred to a future release.
+    <p>This exists because shipping a complete-on-paper system is not the same as shipping a good system. Coverage rows track <em>systems</em>; this checklist tracks <em>experience</em>. Both gates must close.</p>
+  </aside>
+</header>
+
+<section id="how-to-use">
+  <h2>How to use this doc</h2>
+  <ul>
+    <li>Each section captures one experience-level question the systems-level coverage will not catch.</li>
+    <li>Items use <code>&lt;input type="checkbox"&gt;</code> elements. Check when the experience is verified (live playtest, recorded session, or qualitative review).</li>
+    <li>An item that fails review becomes a new <code>F-NNN</code> entry in <code>docs/FOLLOWUPS.html</code> with <code>data-priority="blocks-release"</code>.</li>
+    <li>Re-run the relevant section after any large system lands.</li>
+  </ul>
+</section>
+
+<section data-section="first-90-seconds">
+  <h2>First 90 seconds</h2>
+  <p>The window where a new player decides whether to keep playing.</p>
+  <ul>
+    <li><label><input type="checkbox"> First-time experience does not require external instructions. The user understands the goal within 30 seconds.</label></li>
+    <li><label><input type="checkbox"> First input has a visible, satisfying response (sound, motion, particle, animation).</label></li>
+    <li><label><input type="checkbox"> No dead ends, modal dialogs, or auth walls in the first minute.</label></li>
+    <li><label><input type="checkbox"> If the user does nothing, the screen still communicates what to do.</label></li>
+    <li><label><input type="checkbox"> First completion of the core action delivers a clear positive signal.</label></li>
+  </ul>
+</section>
+
+<section data-section="core-loop-fun">
+  <h2>Core loop fun</h2>
+  <p>The minute-to-minute moment-to-moment quality.</p>
+  <ul>
+    <li><label><input type="checkbox"> The core action is satisfying when performed perfectly.</label></li>
+    <li><label><input type="checkbox"> The core action is satisfying when performed imperfectly (no harsh punishment for trying).</label></li>
+    <li><label><input type="checkbox"> The user can tell, without reading the HUD, whether they are doing well.</label></li>
+    <li><label><input type="checkbox"> Repetition does not become tedious within a 5-minute session.</label></li>
+    <li><label><input type="checkbox"> Difficulty curve has clear progression. Plateaus are intentional.</label></li>
+  </ul>
+</section>
+
+<section data-section="variety-and-surprise">
+  <h2>Variety and surprise</h2>
+  <ul>
+    <li><label><input type="checkbox"> At least three meaningfully different situations / opponents / states / levels exist.</label></li>
+    <li><label><input type="checkbox"> Each variation feels distinct from the others, not a recolor.</label></li>
+    <li><label><input type="checkbox"> Random elements (where applicable) produce surprise without producing frustration.</label></li>
+  </ul>
+</section>
+
+<section data-section="session-arc">
+  <h2>Session arc</h2>
+  <p>The length of time a user wants to play in one sitting.</p>
+  <ul>
+    <li><label><input type="checkbox"> A session has a clear in / play / out flow. The user can stop cleanly.</label></li>
+    <li><label><input type="checkbox"> Progress persists between sessions (saves, leaderboards, profile, settings).</label></li>
+    <li><label><input type="checkbox"> Returning users get a "welcome back" signal (recent items, new options, last-played continuation).</label></li>
+  </ul>
+</section>
+
+<section data-section="audio-and-feel">
+  <h2>Audio and feel</h2>
+  <ul>
+    <li><label><input type="checkbox"> No audio loop is fatiguing after 5 minutes.</label></li>
+    <li><label><input type="checkbox"> Audio reinforces successful actions (positive cues) and warns of failure conditions (negative cues).</label></li>
+    <li><label><input type="checkbox"> The user can mute / adjust audio without leaving the experience.</label></li>
+  </ul>
+</section>
+
+<section data-section="performance-and-reliability">
+  <h2>Performance and reliability</h2>
+  <ul>
+    <li><label><input type="checkbox"> Frame rate stays inside acceptable bounds on the lowest target hardware.</label></li>
+    <li><label><input type="checkbox"> No reproducible crash, hang, or visual artifact in 15 minutes of play.</label></li>
+    <li><label><input type="checkbox"> Loading times are acceptable, or are masked by something the user enjoys watching.</label></li>
+  </ul>
+</section>
+
+<section data-section="accessibility">
+  <h2>Accessibility</h2>
+  <ul>
+    <li><label><input type="checkbox"> Text is readable at the smallest target screen size.</label></li>
+    <li><label><input type="checkbox"> Color is not the sole channel for any critical information.</label></li>
+    <li><label><input type="checkbox"> Keyboard / gamepad / touch parity is maintained for all primary actions.</label></li>
+    <li><label><input type="checkbox"> Motion-sensitive users have a "reduce motion" path.</label></li>
+  </ul>
+</section>
+
+<section data-section="deferred">
+  <h2>Deferred</h2>
+  <p>Items intentionally pushed to a future release. Each one names the release.</p>
+  <p>(none yet)</p>
+</section>
+
+</body>
+</html>

--- a/plugins/spiral-html/templates/PROGRESS_LOG.html
+++ b/plugins/spiral-html/templates/PROGRESS_LOG.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Progress Log</title>
+</head>
+<body>
+
+<header>
+  <h1>Progress Log</h1>
+  <p>Newest entries first. Every implementation slice adds an entry. Append-only: never delete, never reorder, never edit a previous entry.</p>
+  <p>Each slice is an <code>&lt;article data-slice="..." data-date="YYYY-MM-DD"&gt;</code> with the following <code>&lt;dl&gt;</code> entries: <code>Branch</code>, <code>PR</code>, <code>Changed</code>, <code>Verification</code>, <code>Assumptions</code>, <code>GDD coverage</code>, <code>Followups</code>.</p>
+</header>
+
+<section id="template" data-role="entry-template">
+  <h2>How to add a slice entry</h2>
+  <p>Copy this template, fill in the values, and insert it as the new top entry under <code>&lt;main id="entries"&gt;</code>.</p>
+  <pre><code>&lt;article data-slice="short-title" data-date="YYYY-MM-DD"&gt;
+  &lt;h3&gt;Short Title&lt;/h3&gt;
+  &lt;dl&gt;
+    &lt;dt&gt;Branch&lt;/dt&gt;&lt;dd&gt;&lt;code&gt;feature/short-name&lt;/code&gt;&lt;/dd&gt;
+    &lt;dt&gt;PR&lt;/dt&gt;&lt;dd&gt;#N (when known)&lt;/dd&gt;
+    &lt;dt&gt;Changed&lt;/dt&gt;&lt;dd&gt;one paragraph naming the user-facing change and the key files / helpers / defaults that landed.&lt;/dd&gt;
+    &lt;dt&gt;Verification&lt;/dt&gt;&lt;dd&gt;dash checks, type-check, relevant unit tests, build, smoke (where applicable). Note any known-tolerated lint warnings or skipped checks.&lt;/dd&gt;
+    &lt;dt&gt;Assumptions&lt;/dt&gt;&lt;dd&gt;assumptions made under a Recommended default. One sentence per assumption.&lt;/dd&gt;
+    &lt;dt&gt;GDD coverage&lt;/dt&gt;&lt;dd&gt;which rows in &lt;code&gt;docs/GDD_COVERAGE.json&lt;/code&gt; flipped to &lt;code&gt;partial&lt;/code&gt; or &lt;code&gt;done&lt;/code&gt;, or which &lt;code&gt;docs/gdd/*.html&lt;/code&gt; files gained a Build log entry.&lt;/dd&gt;
+    &lt;dt&gt;Followups&lt;/dt&gt;&lt;dd&gt;any new &lt;code&gt;F-NNN&lt;/code&gt; entries created. Link to them.&lt;/dd&gt;
+  &lt;/dl&gt;
+&lt;/article&gt;</code></pre>
+</section>
+
+<main id="entries">
+
+  <article data-slice="spiral-html-scaffold-initialized" data-date="{{TODAY}}">
+    <h3>Spiral-html Scaffold Initialized</h3>
+    <dl>
+      <dt>Branch</dt><dd><code>setup/spiral-html</code></dd>
+      <dt>Changed</dt><dd>bootstrapped the {{PROJECT_NAME}} scaffold using the <code>spiral-html</code> skill. Created <code>AGENTS.html</code>, the <code>AGENTS.md</code> + <code>CLAUDE.md</code> shims, <code>docs/IMPLEMENTATION_PLAN.html</code>, <code>docs/WORKING_AGREEMENT.html</code>, <code>docs/gdd/index.html</code>, <code>docs/GDD_COVERAGE.json</code>, <code>docs/PROGRESS_LOG.html</code>, <code>docs/OPEN_QUESTIONS.html</code>, <code>docs/FOLLOWUPS.html</code>, <code>docs/DEPENDENCY_LEDGER.html</code>, <code>docs/PLAYTEST.html</code>, and <code>docs/FUN_FACTOR_AUDIT.html</code>.</dd>
+      <dt>Verification</dt><dd>em-dash grep returned nothing.</dd>
+      <dt>Assumptions</dt><dd>the GDD will be drafted under <code>docs/gdd/</code> at requirement granularity per the anti-Flatline guardrail in <code>docs/gdd/index.html</code>.</dd>
+      <dt>GDD coverage</dt><dd>ledger created with two example rows; replace these with real requirements before opening any feature PRs.</dd>
+      <dt>Followups</dt><dd>F-001 to draft the first GDD section (vision and pillars).</dd>
+    </dl>
+  </article>
+
+</main>
+
+</body>
+</html>

--- a/plugins/spiral-html/templates/WORKING_AGREEMENT.html
+++ b/plugins/spiral-html/templates/WORKING_AGREEMENT.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Working Agreement: {{PROJECT_NAME}}</title>
+</head>
+<body>
+
+<header>
+  <h1>Working Agreement</h1>
+  <p>This file defines the process rules for implementation slices on <strong>{{PROJECT_NAME}}</strong>.</p>
+</header>
+
+<section id="branches">
+  <h2>Branches</h2>
+  <ul>
+    <li>Start every slice from current <code>main</code>.</li>
+    <li>Branch names should be short and descriptive: <code>feature/manual-shifting</code>, <code>fix/leaderboard-pagination</code>, <code>docs/update-coverage</code>.</li>
+    <li>Never push directly to <code>main</code>.</li>
+    <li>Do not mix unrelated changes in one branch.</li>
+  </ul>
+</section>
+
+<section id="commits">
+  <h2>Commits</h2>
+  <ul>
+    <li>Use short human commit messages.</li>
+    <li>Do not include AI attribution.</li>
+    <li>Keep commits focused. A PR may contain more than one commit when review fixes are added.</li>
+  </ul>
+</section>
+
+<section id="pull-requests">
+  <h2>Pull Requests</h2>
+  <p>Every PR must include:</p>
+  <ul>
+    <li>Summary of user-facing and technical changes.</li>
+    <li>Verification commands run.</li>
+    <li>GDD, coverage, followup, or open-question updates.</li>
+    <li>Any known limitations or blocked checks.</li>
+  </ul>
+  <p>After opening a PR:</p>
+  <ul>
+    <li>Read flat comments, reviews, and threaded inline comments.</li>
+    <li>Treat CodeRabbit or bot review comments as actionable unless clearly incorrect.</li>
+    <li>Fix valid comments and push followup commits.</li>
+    <li>After every followup push, wait for any configured bot reviewer to finish reviewing that pushed commit.</li>
+    <li>The bot review wait is settled only when all required checks are green AND at least 60 seconds have passed since the latest PR branch push or latest bot review activity, whichever is later.</li>
+    <li>Re-read flat reviews and threaded inline comments after each push and after the settled wait. Merge only after bot review is finished or the settled wait confirms no fresh bot feedback appeared.</li>
+    <li>Reply when the context would help future readers.</li>
+    <li>Resolve threads when fixed.</li>
+  </ul>
+</section>
+
+<section id="verification">
+  <h2>Verification</h2>
+  <p>Minimum for docs-only changes:</p>
+  <ul>
+    <li>Dash check (U+2014 em-dash and U+2013 en-dash): <code>grep -rnP '[\x{2014}\x{2013}]' . --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=.next</code> (must return nothing).</li>
+    <li><code>git diff --check</code>.</li>
+    <li>Project-specific type-check command.</li>
+  </ul>
+  <p>Minimum for code changes:</p>
+  <ul>
+    <li>Dash checks.</li>
+    <li><code>git diff --check</code>.</li>
+    <li>Type-check.</li>
+    <li>Relevant unit tests.</li>
+    <li>Full test suite when shared logic, storage, schemas, or core systems are touched.</li>
+    <li>Build command before opening or merging PRs that affect runtime code.</li>
+    <li>Smoke test (Playwright or equivalent) when UI routes, API routes, routing, or core flows are touched.</li>
+  </ul>
+  <p>Minimum for dependency-upgrade slices (<code>chore(deps): bump &lt;dep&gt; from &lt;from&gt; to &lt;to&gt;</code>):</p>
+  <ul>
+    <li>All of the above for code changes.</li>
+    <li>Read the upstream CHANGELOG between the pinned and target version BEFORE editing project code; document the breaking changes and migrations applied in the PR body.</li>
+    <li>Update <code>docs/DEPENDENCY_LEDGER.html</code> <strong>Currently pinned</strong> in the same PR.</li>
+    <li>Smoke test any feature that imports from the upgraded dep.</li>
+    <li>See <code>docs/DEPENDENCY_LEDGER.html</code> §<a href="DEPENDENCY_LEDGER.html#upgrade-procedure">Upgrade procedure</a> for the full step list.</li>
+  </ul>
+  <p>Never mark work complete with failing required verification.</p>
+</section>
+
+<section id="dependency-upgrade-gate">
+  <h2>Dependency Upgrade Gate</h2>
+  <p>Run at every loop boundary that touches <code>main</code>:</p>
+  <ul>
+    <li>After landing on fresh <code>main</code> (post-merge or fresh pull), before picking the next slice.</li>
+    <li>Before opening a new PR, in case a watched release landed while the slice was in flight.</li>
+  </ul>
+  <p>Mechanism lives in <code>docs/IMPLEMENTATION_PLAN.html</code> §<a href="IMPLEMENTATION_PLAN.html#dependency-upgrade-gate">Dependency Upgrade Gate</a>; the watched dep list and per-dep procedure live in <code>docs/DEPENDENCY_LEDGER.html</code>. Treat a new release as a non-optional signal: the upgrade is the next slice unless red CI takes over.</p>
+</section>
+
+<section id="merge-and-deploy">
+  <h2>Merge And Deploy</h2>
+  <ul>
+    <li>Merge only through PRs.</li>
+    <li>Wait for CI, preview deploy, and bot review after the latest push.</li>
+    <li>After merge, pull <code>main</code>.</li>
+    <li>Verify main commit status.</li>
+    <li>Verify production deploy status.</li>
+    <li>Smoke test production with an HTTP check at minimum. Use deeper browser smoke when UI behavior changed.</li>
+  </ul>
+</section>
+
+<section id="clarifications">
+  <h2>Clarifications</h2>
+  <p>Ask only when ambiguity is expensive or risky. When a simple consistent default is available, choose it, record the assumption in <code>docs/OPEN_QUESTIONS.html</code> with a <code>Recommended default</code> entry, and continue.</p>
+</section>
+
+<section id="risk-gates">
+  <h2>Risk Gates</h2>
+  <p>Always stop for explicit user approval before:</p>
+  <ul>
+    <li>Force pushes.</li>
+    <li>Hard resets.</li>
+    <li>Recursive deletes.</li>
+    <li>Dropping data store keys or deleting remote data.</li>
+    <li>Deleting branches other than branches created for the current completed PR.</li>
+    <li>Modifying CI/CD configuration.</li>
+    <li>Uploading content to third-party services outside the existing PR and deploy flow.</li>
+    <li>Handling secrets.</li>
+  </ul>
+</section>
+
+</body>
+</html>

--- a/plugins/spiral-html/templates/docs-gdd-index.html
+++ b/plugins/spiral-html/templates/docs-gdd-index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>GDD: {{PROJECT_NAME}}</title>
+</head>
+<body>
+
+<header>
+  <h1>GDD: {{PROJECT_NAME}}</h1>
+  <aside data-role="guardrail">
+    <strong>Anti-Flatline guardrail.</strong> This GDD is a directory tree, not a single file. Each requirement is its own file. Coverage rows in <code>docs/GDD_COVERAGE.json</code> are written at requirement granularity, NOT chapter granularity. A multi-week project should produce on the order of 100+ rows, not 11. If you only have a dozen rows, your coverage is too coarse and the loop will self-terminate before the product is good.
+  </aside>
+  <p><strong>Project pitch:</strong> {{PITCH}}</p>
+</header>
+
+<section id="how-to-use">
+  <h2>How to use this directory</h2>
+  <ul>
+    <li>Each <code>docs/gdd/&lt;n&gt;-&lt;title&gt;.html</code> file is one requirement or one tightly-scoped section.</li>
+    <li>Each file starts with a <code>&lt;p data-status="..."&gt;</code> element: <code>not_started</code> | <code>partial</code> | <code>done</code>.</li>
+    <li>Once a file's work ships, append a <code>&lt;section data-role="build-log"&gt;</code> with what landed, the key files, and any non-obvious decisions. Build logs grow with the code.</li>
+    <li>Keep file names short and stable. The file path is referenced from <code>GDD_COVERAGE.json</code>.</li>
+  </ul>
+</section>
+
+<section id="conventions">
+  <h2>Conventions</h2>
+  <ul>
+    <li>One requirement, one file, one row in the coverage ledger.</li>
+    <li>File names: <code>&lt;NN&gt;-&lt;kebab-title&gt;.html</code>, e.g. <code>05-vehicle-physics.html</code>, <code>12-leaderboard-submit.html</code>.</li>
+    <li>Cross-references between sections use relative links.</li>
+    <li>The em-dash ban applies here.</li>
+  </ul>
+</section>
+
+<section id="index">
+  <h2>Index</h2>
+  <p>Add entries below as sections are drafted. Each entry: filename + one-line description. This index is the human-readable map; the machine-readable map is <code>docs/GDD_COVERAGE.json</code>.</p>
+  <ul>
+    <li><code>01-vision-and-pillars.html</code>: what {{PROJECT_NAME}} is and what it is not.</li>
+    <li><em>&lt;draft your first requirement file here&gt;</em></li>
+  </ul>
+</section>
+
+<section id="out-of-scope">
+  <h2>Out of scope</h2>
+  <p>A dedicated <code>docs/gdd/99-out-of-scope.html</code> file is the explicit fence. List anything that has been considered and rejected for v1, with a one-line rationale. The loop must not scope-creep into items listed there without approval.</p>
+</section>
+
+</body>
+</html>

--- a/plugins/spiral-html/templates/dot-claude-rules-gdd-build-log.md
+++ b/plugins/spiral-html/templates/dot-claude-rules-gdd-build-log.md
@@ -1,0 +1,61 @@
+---
+description: Every shipped feature appends a Build log entry to the relevant GDD section.
+paths:
+  - "docs/gdd/**.html"
+---
+
+<h1>GDD build log discipline</h1>
+
+<p>This rule loads when editing GDD section files. Each section is the canonical spec for one requirement. Build logs grow with the code so the next slice can read what landed without rediscovering it.</p>
+
+<h2>What to do</h2>
+
+<p>Every GDD section file follows this shape:</p>
+
+<pre><code>&lt;!DOCTYPE html&gt;
+&lt;html lang="en"&gt;
+&lt;head&gt;&lt;meta charset="utf-8"&gt;&lt;title&gt;&lt;Requirement title&gt;&lt;/title&gt;&lt;/head&gt;
+&lt;body&gt;
+
+  &lt;h1&gt;&lt;Requirement title&gt;&lt;/h1&gt;
+  &lt;p data-status="not_started|partial|done"&gt;Status: &lt;status&gt;&lt;/p&gt;
+
+  &lt;section data-role="spec"&gt;
+    &lt;p&gt;Spec text: what the feature is, what it does, what it does NOT do.&lt;/p&gt;
+  &lt;/section&gt;
+
+  &lt;section data-role="build-log"&gt;
+    &lt;h2&gt;Build log&lt;/h2&gt;
+    &lt;ul&gt;
+      &lt;li data-date="YYYY-MM-DD"&gt;one-line summary of what shipped. Files: &lt;code&gt;src/...&lt;/code&gt;, &lt;code&gt;tests/...&lt;/code&gt;. PR #N.&lt;/li&gt;
+      &lt;li data-date="YYYY-MM-DD"&gt;Earlier entry&lt;/li&gt;
+      &lt;li data-date="YYYY-MM-DD"&gt;Earliest entry, kept verbatim&lt;/li&gt;
+    &lt;/ul&gt;
+  &lt;/section&gt;
+
+&lt;/body&gt;
+&lt;/html&gt;
+</code></pre>
+
+<p>When a slice touches the requirement covered by this file:</p>
+
+<ol>
+  <li>Update the <code>&lt;p data-status="..."&gt;</code> value if the status changed (<code>not_started</code> → <code>partial</code>, <code>partial</code> → <code>done</code>).</li>
+  <li>Append a new <code>&lt;li data-date="..."&gt;</code> to the top of the <code>&lt;section data-role="build-log"&gt;</code> list.</li>
+  <li>The build log entry MUST name the key files added or modified.</li>
+  <li>The build log entry MUST link the PR number once known.</li>
+  <li>Do NOT rewrite past build log entries, even if the implementation has since changed. Add a new entry instead.</li>
+</ol>
+
+<h2>What to avoid</h2>
+
+<ul>
+  <li>Updating the spec text to match what shipped (the spec is the <em>intent</em>; the build log is <em>what landed</em>).</li>
+  <li>Removing the <code>data-status</code> attribute.</li>
+  <li>Removing or rewriting past build log entries.</li>
+  <li>Splitting one feature across multiple GDD section files (the granularity of <code>docs/GDD_COVERAGE.json</code> rows is the right unit).</li>
+</ul>
+
+<h2>Why this matters</h2>
+
+<p>Build logs are how the next slice starts cheap. A new slice working in a touched area reads the most recent build log entries to understand what files own the behavior, what defaults were chosen, and what assumptions are still live. Without build logs, every slice pays the rediscovery tax. With them, the spiral compounds.</p>

--- a/plugins/spiral-html/templates/dot-claude-rules-ledger-append-only.md
+++ b/plugins/spiral-html/templates/dot-claude-rules-ledger-append-only.md
@@ -1,0 +1,54 @@
+---
+description: Ledger files are append-only. Never delete or rewrite past entries.
+paths:
+  - "docs/PROGRESS_LOG.html"
+  - "docs/OPEN_QUESTIONS.html"
+  - "docs/FOLLOWUPS.html"
+  - "docs/GDD_COVERAGE.json"
+---
+
+<h1>Ledger append-only discipline</h1>
+
+<p>This rule loads when editing the four ledger files. They are the externalized memory of the project. The agent does not remember; the project remembers itself. That contract breaks if past entries are rewritten.</p>
+
+<h2>What to do</h2>
+
+<section data-ledger="docs/PROGRESS_LOG.html">
+  <h3><code>docs/PROGRESS_LOG.html</code></h3>
+  <ul>
+    <li>Add new <code>&lt;article data-slice="..."&gt;</code> entries at the TOP of the relevant section. Newest first.</li>
+    <li>Never edit a past entry. If a past entry is wrong, add a new entry that corrects it.</li>
+    <li>Every implementation slice gets its own article. Required <code>&lt;dl&gt;</code> fields: Branch / PR / Changed / Verification / Assumptions / GDD coverage / Followups.</li>
+  </ul>
+</section>
+
+<section data-ledger="docs/OPEN_QUESTIONS.html">
+  <h3><code>docs/OPEN_QUESTIONS.html</code></h3>
+  <ul>
+    <li>New questions get the next monotonic <code>Q-NNN</code> id (set on the <code>&lt;section data-q="..."&gt;</code>).</li>
+    <li>When a question resolves, leave the entry in place. Update <code>data-status</code> to <code>resolved</code> and fill in the <code>Resolution</code> entry. Move the entry under the <code>&lt;aside id="resolved"&gt;</code> region.</li>
+    <li>Never delete a past question, even if it was wrong. Add a new question that supersedes it and reference the old id in the <code>Resolution</code> entry.</li>
+  </ul>
+</section>
+
+<section data-ledger="docs/FOLLOWUPS.html">
+  <h3><code>docs/FOLLOWUPS.html</code></h3>
+  <ul>
+    <li>New followups get the next monotonic <code>F-NNN</code> id (set on the <code>&lt;section data-f="..."&gt;</code>).</li>
+    <li>When a followup ships, leave the entry in place and append a <code>&lt;dt&gt;Resolved&lt;/dt&gt;&lt;dd&gt;PR #N&lt;/dd&gt;</code> pair. Move under a <code>&lt;main id="resolved"&gt;</code> region if you have one.</li>
+    <li>Never delete a past followup, even if it became irrelevant. Add a <code>&lt;dt&gt;Resolved&lt;/dt&gt;&lt;dd&gt;N/A (dropped because &lt;reason&gt;)&lt;/dd&gt;</code> pair and move it.</li>
+  </ul>
+</section>
+
+<section data-ledger="docs/GDD_COVERAGE.json">
+  <h3><code>docs/GDD_COVERAGE.json</code></h3>
+  <ul>
+    <li>Update <code>status</code> and append to <code>implementationRefs</code> / <code>testRefs</code> / <code>followupRefs</code> as work ships.</li>
+    <li>Do not delete rows whose requirements got cut. Set <code>status: "out_of_scope"</code> and add a note.</li>
+    <li>The <code>id</code> of a row is permanent. Do not renumber.</li>
+  </ul>
+</section>
+
+<h2>Why this matters</h2>
+
+<p>A future slice cannot trust ledgers that get retroactively edited. The audit trail is the contract. Treating these files as a database (overwrite + delete) destroys the institutional memory that lets the spiral run for weeks.</p>

--- a/plugins/spiral-html/templates/dot-claude-rules-slice-discipline.md
+++ b/plugins/spiral-html/templates/dot-claude-rules-slice-discipline.md
@@ -1,0 +1,39 @@
+---
+description: Keep slice changes scoped. No drive-by refactors, no speculative abstractions.
+paths:
+  - "src/**"
+  - "app/**"
+  - "lib/**"
+  - "components/**"
+  - "pages/**"
+  - "scripts/**"
+  - "tests/**"
+---
+
+<h1>Slice discipline</h1>
+
+<p>This rule loads when editing source code under typical project layouts. It enforces the slice contract from <code>docs/IMPLEMENTATION_PLAN.html</code>.</p>
+
+<h2>What to do</h2>
+
+<ul>
+  <li>Touch only what the current slice needs. If you find yourself "while I'm here" cleaning a separate file, stop. That is a separate slice.</li>
+  <li>Refactors land as part of the slice that touches the code, not as a separate invisible cleanup pass.</li>
+  <li>Three similar lines is better than a premature abstraction. Wait for the third repetition before extracting.</li>
+  <li>Do not add error handling, fallbacks, or validation for scenarios that cannot happen. Trust internal code and framework guarantees. Validate at system boundaries only.</li>
+  <li>Do not add features, refactor, or introduce abstractions beyond what the task requires. A bug fix does not need surrounding cleanup.</li>
+</ul>
+
+<h2>What to avoid</h2>
+
+<ul>
+  <li>Tangential file edits ("while I'm here, let me also...").</li>
+  <li>Backwards-compat shims for code you can just change.</li>
+  <li>Renaming unused vars to silence the linter.</li>
+  <li>Speculative comments explaining future-hypothetical scenarios.</li>
+  <li>Half-finished implementations.</li>
+</ul>
+
+<h2>Why this matters</h2>
+
+<p>Every slice that touches files outside its scope makes the next slice harder to review and harder to revert if it regresses. The smaller and tighter the slice, the cheaper the spiral compounds.</p>


### PR DESCRIPTION
## Summary

- Adds `plugins/spiral-html/`, a parallel skill that mirrors `spiral` but writes the entire scaffold (rules, ledgers, plan, agreement, GDD index, playtest, fun-factor audit, dependency ledger, progress log) as HTML instead of Markdown.
- Ledger entries use semantic `data-*` attributes (`data-q`, `data-f`, `data-priority`, `data-status`, `data-date`) so the audit script can grep for structural facts instead of heading prefixes.
- Cross-tool compatibility preserved with tiny `AGENTS.md` and `CLAUDE.md` shims that point at `AGENTS.html`. Path-scoped rules under `.claude/rules` keep their YAML frontmatter and `.md` filenames (required by Claude Code's path-globbing) with HTML bodies.
- `init.sh` and `audit.sh` rewritten for the HTML layout. Verified end-to-end in a scratch git repo: clean init produces a clean audit, and seeded breakages (missing playtest / fun-factor, missing `<dt>Recommended default</dt>`, missing `data-priority`) all fire findings and return non-zero.
- Registered in `.claude-plugin/marketplace.json` and the root `README.md` install/usage tables.

## Test plan

- [x] Em-dash check on the new tree (`grep -rnP '[\x{2014}\x{2013}]' plugins/spiral-html/`)
- [x] JSON validation of `plugin.json`, `GDD_COVERAGE.json` template, `marketplace.json`
- [x] `bash scripts/init.sh` in a scratch repo writes every expected file and the audit returns clean
- [x] Breaking the playtest, fun-factor, recommended-default, and priority constraints in the scratch repo causes the audit to fire findings and exit non-zero

## TODO: try the same conversion for the dots CLI

The natural follow-up is to do the same HTML-first conversion against the dots CLI fork at [Randroids-Dojo/dots-html](https://github.com/Randroids-Dojo/dots-html). That repo is the Zig source for the `dot` CLI, so the conversion is meaningfully bigger than this PR:

- `.dots/*.md` storage files would move to `.dots/*.html` (YAML frontmatter retained inside each HTML file is the smallest change; pushing metadata into `<head><meta>` / `data-*` is the bigger one).
- `src/storage.zig` parser, snapshot tests, and `migrate-dots.sh` would need updates.
- `README.md`, `AGENTS.md`, and `docs/zig-0.15-api.md` would also flip to HTML for consistency.

Deferred for a later session; this PR is scaffolding-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsrwByHZq5TfY3BMjsRrH5)_